### PR TITLE
Introduce support for TypeScript 5.0

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npx vitest run
+      - run: npm test
 
   test_ts:
     name: TypeScript @${{ matrix.ts-version }}
@@ -43,10 +43,11 @@ jobs:
           - ~4.7
           - ~4.8
           - ~4.9
+          - ~5.0
           - next
     steps:
       - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - run: npm ci
       - run: npm i -D typescript@${{ matrix.ts-version }}
-      - run: npx vitest run
+      - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,18 @@
             "license": "Apache-2.0",
             "devDependencies": {
                 "@neotype/prelude": "^0.8",
-                "@typescript-eslint/eslint-plugin": "^5.30.5",
-                "@typescript-eslint/parser": "^5.30.5",
+                "@typescript-eslint/eslint-plugin": "^5.55.0",
+                "@typescript-eslint/parser": "^5.55.0",
                 "@vitest/coverage-c8": "^0.29.3",
-                "eslint": "^8.19.0",
-                "eslint-config-prettier": "^8.5.0",
-                "eslint-plugin-import": "^2.26.0",
-                "fast-check": "^3.1.4",
-                "prettier": "2.7.1",
-                "prettier-plugin-organize-imports": "^3.1.1",
+                "eslint": "^8.36.0",
+                "eslint-config-prettier": "^8.8.0",
+                "eslint-plugin-import": "^2.27.5",
+                "fast-check": "^3.7.1",
+                "prettier": "2.8.6",
+                "prettier-plugin-organize-imports": "^3.2.2",
                 "rimraf": "^3.0.2",
-                "ts-node": "^10.8.2",
-                "typescript": "~4.9",
+                "ts-node": "^10.9.1",
+                "typescript": "~5.0",
                 "vitest": "^0.29.3"
             },
             "engines": {
@@ -401,15 +401,39 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.3.0.tgz",
+            "integrity": "sha512-v3oplH6FYCULtFuCeqyuTd9D2WKO937Dxdq+GmHOLL72TTRriLxz2VLlNfkZRsvj6PKnOPAtuT6dwrs/pA5DvA==",
+            "dev": true,
+            "dependencies": {
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.1.tgz",
+            "integrity": "sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw==",
+            "dev": true,
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-            "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
+            "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.4.0",
+                "espree": "^9.5.0",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -422,6 +446,15 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "8.36.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
+            "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -593,9 +626,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.11.18",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-            "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+            "version": "18.15.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.5.tgz",
+            "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==",
             "dev": true
         },
         "node_modules/@types/semver": {
@@ -605,18 +638,19 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.2.tgz",
-            "integrity": "sha512-sR0Gja9Ky1teIq4qJOl0nC+Tk64/uYdX+mi+5iB//MH8gwyx8e3SOyhEzeLZEFEEfCaLf8KJq+Bd/6je1t+CAg==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.56.0.tgz",
+            "integrity": "sha512-ZNW37Ccl3oMZkzxrYDUX4o7cnuPgU+YrcaYXzsRtLB16I1FR5SHMqga3zGsaSliZADCWo2v8qHWqAYIj8nWCCg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.48.2",
-                "@typescript-eslint/type-utils": "5.48.2",
-                "@typescript-eslint/utils": "5.48.2",
+                "@eslint-community/regexpp": "^4.4.0",
+                "@typescript-eslint/scope-manager": "5.56.0",
+                "@typescript-eslint/type-utils": "5.56.0",
+                "@typescript-eslint/utils": "5.56.0",
                 "debug": "^4.3.4",
+                "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "natural-compare-lite": "^1.4.0",
-                "regexpp": "^3.2.0",
                 "semver": "^7.3.7",
                 "tsutils": "^3.21.0"
             },
@@ -638,14 +672,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.2.tgz",
-            "integrity": "sha512-38zMsKsG2sIuM5Oi/olurGwYJXzmtdsHhn5mI/pQogP+BjYVkK5iRazCQ8RGS0V+YLk282uWElN70zAAUmaYHw==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.56.0.tgz",
+            "integrity": "sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.48.2",
-                "@typescript-eslint/types": "5.48.2",
-                "@typescript-eslint/typescript-estree": "5.48.2",
+                "@typescript-eslint/scope-manager": "5.56.0",
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/typescript-estree": "5.56.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -665,13 +699,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.2.tgz",
-            "integrity": "sha512-zEUFfonQid5KRDKoI3O+uP1GnrFd4tIHlvs+sTJXiWuypUWMuDaottkJuR612wQfOkjYbsaskSIURV9xo4f+Fw==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.56.0.tgz",
+            "integrity": "sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.48.2",
-                "@typescript-eslint/visitor-keys": "5.48.2"
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/visitor-keys": "5.56.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -682,13 +716,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.2.tgz",
-            "integrity": "sha512-QVWx7J5sPMRiOMJp5dYshPxABRoZV1xbRirqSk8yuIIsu0nvMTZesKErEA3Oix1k+uvsk8Cs8TGJ6kQ0ndAcew==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz",
+            "integrity": "sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.48.2",
-                "@typescript-eslint/utils": "5.48.2",
+                "@typescript-eslint/typescript-estree": "5.56.0",
+                "@typescript-eslint/utils": "5.56.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -709,9 +743,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.2.tgz",
-            "integrity": "sha512-hE7dA77xxu7ByBc6KCzikgfRyBCTst6dZQpwaTy25iMYOnbNljDT4hjhrGEJJ0QoMjrfqrx+j1l1B9/LtKeuqA==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.56.0.tgz",
+            "integrity": "sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -722,13 +756,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.2.tgz",
-            "integrity": "sha512-bibvD3z6ilnoVxUBFEgkO0k0aFvUc4Cttt0dAreEr+nrAHhWzkO83PEVVuieK3DqcgL6VAK5dkzK8XUVja5Zcg==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.56.0.tgz",
+            "integrity": "sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.48.2",
-                "@typescript-eslint/visitor-keys": "5.48.2",
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/visitor-keys": "5.56.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -749,18 +783,18 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.2.tgz",
-            "integrity": "sha512-2h18c0d7jgkw6tdKTlNaM7wyopbLRBiit8oAxoP89YnuBOzCZ8g8aBCaCqq7h208qUTroL7Whgzam7UY3HVLow==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.56.0.tgz",
+            "integrity": "sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==",
             "dev": true,
             "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
                 "@types/json-schema": "^7.0.9",
                 "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.48.2",
-                "@typescript-eslint/types": "5.48.2",
-                "@typescript-eslint/typescript-estree": "5.48.2",
+                "@typescript-eslint/scope-manager": "5.56.0",
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/typescript-estree": "5.56.0",
                 "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0",
                 "semver": "^7.3.7"
             },
             "engines": {
@@ -775,12 +809,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.2.tgz",
-            "integrity": "sha512-z9njZLSkwmjFWUelGEwEbdf4NwKvfHxvGC0OcGN1Hp/XNDIcJ7D5DpPNPv6x6/mFvc1tQHsaWmpD/a4gOvvCJQ==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.56.0.tgz",
+            "integrity": "sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.48.2",
+                "@typescript-eslint/types": "5.56.0",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -792,9 +826,9 @@
             }
         },
         "node_modules/@vitest/coverage-c8": {
-            "version": "0.29.3",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.29.3.tgz",
-            "integrity": "sha512-VMhCCkkd9E2J1U3OVQop2fT7PRutqNA+kjaiXkYKz6+ap5TcH+m5+61oE6bJNGn/pN6i5cL6nDqzrbl9wixFng==",
+            "version": "0.29.7",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.29.7.tgz",
+            "integrity": "sha512-TSubtP9JFBuI/wuApxwknHe40VDkX8hFbBak0OXj4/jCeXrEu5B5GPWcxzyk9YvzXgCaDvoiZV79I7AvhNI9YQ==",
             "dev": true,
             "dependencies": {
                 "c8": "^7.13.0",
@@ -809,23 +843,23 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "0.29.3",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.29.3.tgz",
-            "integrity": "sha512-z/0JqBqqrdtrT/wzxNrWC76EpkOHdl+SvuNGxWulLaoluygntYyG5wJul5u/rQs5875zfFz/F+JaDf90SkLUIg==",
+            "version": "0.29.7",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.29.7.tgz",
+            "integrity": "sha512-UtG0tW0DP6b3N8aw7PHmweKDsvPv4wjGvrVZW7OSxaFg76ShtVdMiMcUkZJgCE8QWUmhwaM0aQhbbVLo4F4pkA==",
             "dev": true,
             "dependencies": {
-                "@vitest/spy": "0.29.3",
-                "@vitest/utils": "0.29.3",
+                "@vitest/spy": "0.29.7",
+                "@vitest/utils": "0.29.7",
                 "chai": "^4.3.7"
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "0.29.3",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.29.3.tgz",
-            "integrity": "sha512-XLi8ctbvOWhUWmuvBUSIBf8POEDH4zCh6bOuVxm/KGfARpgmVF1ku+vVNvyq85va+7qXxtl+MFmzyXQ2xzhAvw==",
+            "version": "0.29.7",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.29.7.tgz",
+            "integrity": "sha512-Yt0+csM945+odOx4rjZSjibQfl2ymxqVsmYz6sO2fiO5RGPYDFCo60JF6tLL9pz4G/kjY4irUxadeB1XT+H1jg==",
             "dev": true,
             "dependencies": {
-                "@vitest/utils": "0.29.3",
+                "@vitest/utils": "0.29.7",
                 "p-limit": "^4.0.0",
                 "pathe": "^1.1.0"
             }
@@ -858,24 +892,33 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "0.29.3",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.29.3.tgz",
-            "integrity": "sha512-LLpCb1oOCOZcBm0/Oxbr1DQTuKLRBsSIHyLYof7z4QVE8/v8NcZKdORjMUq645fcfX55+nLXwU/1AQ+c2rND+w==",
+            "version": "0.29.7",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.29.7.tgz",
+            "integrity": "sha512-IalL0iO6A6Xz8hthR8sctk6ZS//zVBX48EiNwQguYACdgdei9ZhwMaBFV70mpmeYAFCRAm+DpoFHM5470Im78A==",
             "dev": true,
             "dependencies": {
                 "tinyspy": "^1.0.2"
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "0.29.3",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.29.3.tgz",
-            "integrity": "sha512-hg4Ff8AM1GtUnLpUJlNMxrf9f4lZr/xRJjh3uJ0QFP+vjaW82HAxKrmeBmLnhc8Os2eRf+f+VBu4ts7TafPPkA==",
+            "version": "0.29.7",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.29.7.tgz",
+            "integrity": "sha512-vNgGadp2eE5XKCXtZXL5UyNEDn68npSct75OC9AlELenSK0DiV1Mb9tfkwJHKjRb69iek+e79iipoJx8+s3SdA==",
             "dev": true,
             "dependencies": {
                 "cli-truncate": "^3.1.0",
                 "diff": "^5.1.0",
                 "loupe": "^2.3.6",
                 "pretty-format": "^27.5.1"
+            }
+        },
+        "node_modules/@vitest/utils/node_modules/diff": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+            "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
             }
         },
         "node_modules/acorn": {
@@ -959,6 +1002,19 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
+        },
+        "node_modules/array-buffer-byte-length": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+            "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "is-array-buffer": "^3.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/array-includes": {
             "version": "3.1.6",
@@ -1315,9 +1371,9 @@
             "dev": true
         },
         "node_modules/define-properties": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+            "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
             "dev": true,
             "dependencies": {
                 "has-property-descriptors": "^1.0.0",
@@ -1331,9 +1387,9 @@
             }
         },
         "node_modules/diff": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-            "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true,
             "engines": {
                 "node": ">=0.3.1"
@@ -1376,18 +1432,18 @@
             "dev": true
         },
         "node_modules/es-abstract": {
-            "version": "1.21.1",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
-            "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+            "version": "1.21.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+            "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
             "dev": true,
             "dependencies": {
+                "array-buffer-byte-length": "^1.0.0",
                 "available-typed-arrays": "^1.0.5",
                 "call-bind": "^1.0.2",
                 "es-set-tostringtag": "^2.0.1",
                 "es-to-primitive": "^1.2.1",
-                "function-bind": "^1.1.1",
                 "function.prototype.name": "^1.1.5",
-                "get-intrinsic": "^1.1.3",
+                "get-intrinsic": "^1.2.0",
                 "get-symbol-description": "^1.0.0",
                 "globalthis": "^1.0.3",
                 "gopd": "^1.0.1",
@@ -1395,8 +1451,8 @@
                 "has-property-descriptors": "^1.0.0",
                 "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3",
-                "internal-slot": "^1.0.4",
-                "is-array-buffer": "^3.0.1",
+                "internal-slot": "^1.0.5",
+                "is-array-buffer": "^3.0.2",
                 "is-callable": "^1.2.7",
                 "is-negative-zero": "^2.0.2",
                 "is-regex": "^1.1.4",
@@ -1404,11 +1460,12 @@
                 "is-string": "^1.0.7",
                 "is-typed-array": "^1.1.10",
                 "is-weakref": "^1.0.2",
-                "object-inspect": "^1.12.2",
+                "object-inspect": "^1.12.3",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.4",
                 "regexp.prototype.flags": "^1.4.3",
                 "safe-regex-test": "^1.0.0",
+                "string.prototype.trim": "^1.2.7",
                 "string.prototype.trimend": "^1.0.6",
                 "string.prototype.trimstart": "^1.0.6",
                 "typed-array-length": "^1.0.4",
@@ -1521,12 +1578,15 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.32.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
-            "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+            "version": "8.36.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+            "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
             "dev": true,
             "dependencies": {
-                "@eslint/eslintrc": "^1.4.1",
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.4.0",
+                "@eslint/eslintrc": "^2.0.1",
+                "@eslint/js": "8.36.0",
                 "@humanwhocodes/config-array": "^0.11.8",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -1537,10 +1597,9 @@
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
                 "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.4.0",
-                "esquery": "^1.4.0",
+                "espree": "^9.5.0",
+                "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
@@ -1561,7 +1620,6 @@
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
                 "strip-ansi": "^6.0.1",
                 "strip-json-comments": "^3.1.0",
                 "text-table": "^0.2.0"
@@ -1577,9 +1635,9 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
-            "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+            "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
             "dev": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
@@ -1706,33 +1764,6 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "dependencies": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "engines": {
-                "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            },
-            "peerDependencies": {
-                "eslint": ">=5"
-            }
-        },
-        "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/eslint-visitor-keys": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
@@ -1765,9 +1796,9 @@
             }
         },
         "node_modules/espree": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
+            "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
             "dev": true,
             "dependencies": {
                 "acorn": "^8.8.0",
@@ -1782,9 +1813,9 @@
             }
         },
         "node_modules/esquery": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+            "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
             "dev": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -1842,9 +1873,9 @@
             }
         },
         "node_modules/fast-check": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.6.2.tgz",
-            "integrity": "sha512-htRkbkw8B1yVfvrLNiJTnpcvpXrdcgpwZUQdC07dsiUGXaHHWK38t6VCnTmAUf68atyos1+XXXY60VUbSgorAQ==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.7.1.tgz",
+            "integrity": "sha512-d63EsxP1eedA+x94xNxIpTWtBShq95KL6ZSrKTD0Pp1lPASmajAaDHJ71c5ebwZ+vBzlTt3AOalcAnBzL7PQ6Q==",
             "dev": true,
             "funding": [
                 {
@@ -2101,15 +2132,15 @@
             }
         },
         "node_modules/glob": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^3.0.4",
+                "minimatch": "^3.1.1",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
             },
@@ -2133,9 +2164,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.19.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
-            "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+            "version": "13.20.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+            "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -2338,12 +2369,12 @@
             "dev": true
         },
         "node_modules/internal-slot": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
-            "integrity": "sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+            "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
             "dev": true,
             "dependencies": {
-                "get-intrinsic": "^1.1.3",
+                "get-intrinsic": "^1.2.0",
                 "has": "^1.0.3",
                 "side-channel": "^1.0.4"
             },
@@ -2352,13 +2383,13 @@
             }
         },
         "node_modules/is-array-buffer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
-            "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+            "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
+                "get-intrinsic": "^1.2.0",
                 "is-typed-array": "^1.1.10"
             },
             "funding": {
@@ -2642,9 +2673,9 @@
             }
         },
         "node_modules/js-sdsl": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-            "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+            "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -2825,9 +2856,9 @@
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -3116,9 +3147,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-            "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+            "version": "2.8.6",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.6.tgz",
+            "integrity": "sha512-mtuzdiBbHwPEgl7NxWlqOkithPyp4VN93V7VeHVWBF+ad3I5avc0RVDT4oImXQy9H/AqxA2NSQH8pSxHW6FYbQ==",
             "dev": true,
             "bin": {
                 "prettier": "bin-prettier.js"
@@ -3186,9 +3217,9 @@
             }
         },
         "node_modules/pure-rand": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.0.tgz",
-            "integrity": "sha512-rLSBxJjP+4DQOgcJAx6RZHT2he2pkhQdSnofG5VWyVl6GRq/K02ISOuOLcsMOrtKDIJb8JN2zm3FFzWNbezdPw==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.1.tgz",
+            "integrity": "sha512-t+x1zEHDjBwkDGY5v5ApnZ/utcd4XYDiJsaQQoptTXgUXX95sDg1elCdJghzicm7n2mbCBJ3uYWr6M22SO19rg==",
             "dev": true,
             "funding": [
                 {
@@ -3242,18 +3273,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
             }
         },
         "node_modules/require-directory": {
@@ -3317,9 +3336,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "3.19.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.19.1.tgz",
-            "integrity": "sha512-lAbrdN7neYCg/8WaoWn/ckzCtz+jr70GFfYdlf50OF7387HTg+wiuiqJRFYawwSPpqfqDNYqK7smY/ks2iAudg==",
+            "version": "3.20.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.1.tgz",
+            "integrity": "sha512-sz2w8cBJlWQ2E17RcpvHuf4sk2BQx4tfKDnjNPikEpLEevrbIAR7CH3PGa2hpPwWbNgPaA9yh9Jzljds5bc9zg==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -3542,6 +3561,23 @@
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
+        "node_modules/string.prototype.trim": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+            "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/string.prototype.trimend": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
@@ -3666,9 +3702,9 @@
             "dev": true
         },
         "node_modules/tinypool": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.3.1.tgz",
-            "integrity": "sha512-zLA1ZXlstbU2rlpA4CIeVaqvWq41MTWqLY3FfsAXgC8+f7Pk7zroaJQxDgxn1xNudKW6Kmj4808rPFShUlIRmQ==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.4.0.tgz",
+            "integrity": "sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==",
             "dev": true,
             "engines": {
                 "node": ">=14.0.0"
@@ -3738,23 +3774,14 @@
                 }
             }
         },
-        "node_modules/ts-node/node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
         "node_modules/tsconfig-paths": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-            "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+            "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
             "dev": true,
             "dependencies": {
                 "@types/json5": "^0.0.29",
-                "json5": "^1.0.1",
+                "json5": "^1.0.2",
                 "minimist": "^1.2.6",
                 "strip-bom": "^3.0.0"
             }
@@ -3828,16 +3855,16 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+            "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=12.20"
             }
         },
         "node_modules/ufo": {
@@ -3901,9 +3928,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.2.0.tgz",
-            "integrity": "sha512-AbDTyzzwuKoRtMIRLGNxhLRuv1FpRgdIw+1y6AQG73Q5+vtecmvzKo/yk8X/vrHDpETRTx01ABijqUHIzBXi0g==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.2.1.tgz",
+            "integrity": "sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.17.5",
@@ -3950,9 +3977,9 @@
             }
         },
         "node_modules/vite-node": {
-            "version": "0.29.3",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.29.3.tgz",
-            "integrity": "sha512-QYzYSA4Yt2IiduEjYbccfZQfxKp+T1Do8/HEpSX/G5WIECTFKJADwLs9c94aQH4o0A+UtCKU61lj1m5KvbxxQA==",
+            "version": "0.29.7",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.29.7.tgz",
+            "integrity": "sha512-PakCZLvz37yFfUPWBnLa1OYHPCGm5v4pmRrTcFN4V/N/T3I6tyP3z07S//9w+DdeL7vVd0VSeyMZuAh+449ZWw==",
             "dev": true,
             "dependencies": {
                 "cac": "^6.7.14",
@@ -3973,18 +4000,18 @@
             }
         },
         "node_modules/vitest": {
-            "version": "0.29.3",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.29.3.tgz",
-            "integrity": "sha512-muMsbXnZsrzDGiyqf/09BKQsGeUxxlyLeLK/sFFM4EXdURPQRv8y7dco32DXaRORYP0bvyN19C835dT23mL0ow==",
+            "version": "0.29.7",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.29.7.tgz",
+            "integrity": "sha512-aWinOSOu4jwTuZHkb+cCyrqQ116Q9TXaJrNKTHudKBknIpR0VplzeaOUuDF9jeZcrbtQKZQt6yrtd+eakbaxHg==",
             "dev": true,
             "dependencies": {
                 "@types/chai": "^4.3.4",
                 "@types/chai-subset": "^1.3.3",
                 "@types/node": "*",
-                "@vitest/expect": "0.29.3",
-                "@vitest/runner": "0.29.3",
-                "@vitest/spy": "0.29.3",
-                "@vitest/utils": "0.29.3",
+                "@vitest/expect": "0.29.7",
+                "@vitest/runner": "0.29.7",
+                "@vitest/spy": "0.29.7",
+                "@vitest/utils": "0.29.7",
                 "acorn": "^8.8.1",
                 "acorn-walk": "^8.2.0",
                 "cac": "^6.7.14",
@@ -3997,10 +4024,10 @@
                 "std-env": "^3.3.1",
                 "strip-literal": "^1.0.0",
                 "tinybench": "^2.3.1",
-                "tinypool": "^0.3.1",
+                "tinypool": "^0.4.0",
                 "tinyspy": "^1.0.2",
                 "vite": "^3.0.0 || ^4.0.0",
-                "vite-node": "0.29.3",
+                "vite-node": "0.29.7",
                 "why-is-node-running": "^2.2.2"
             },
             "bin": {
@@ -4033,6 +4060,12 @@
                     "optional": true
                 },
                 "jsdom": {
+                    "optional": true
+                },
+                "safaridriver": {
+                    "optional": true
+                },
+                "webdriverio": {
                     "optional": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -78,18 +78,18 @@
     },
     "devDependencies": {
         "@neotype/prelude": "^0.8",
-        "@typescript-eslint/eslint-plugin": "^5.30.5",
-        "@typescript-eslint/parser": "^5.30.5",
+        "@typescript-eslint/eslint-plugin": "^5.55.0",
+        "@typescript-eslint/parser": "^5.55.0",
         "@vitest/coverage-c8": "^0.29.3",
-        "eslint": "^8.19.0",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-import": "^2.26.0",
-        "fast-check": "^3.1.4",
-        "prettier": "2.7.1",
-        "prettier-plugin-organize-imports": "^3.1.1",
+        "eslint": "^8.36.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-import": "^2.27.5",
+        "fast-check": "^3.7.1",
+        "prettier": "2.8.6",
+        "prettier-plugin-organize-imports": "^3.2.2",
         "rimraf": "^3.0.2",
-        "ts-node": "^10.8.2",
-        "typescript": "~4.9",
+        "ts-node": "^10.9.1",
+        "typescript": "~5.0",
         "vitest": "^0.29.3"
     },
     "eslintConfig": {
@@ -112,9 +112,11 @@
             "@typescript-eslint"
         ],
         "rules": {
-            "@typescript-eslint/no-namespace": [
-                "off"
-            ],
+            "@typescript-eslint/consistent-type-imports": "error",
+            "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/no-import-type-side-effects": "error",
+            "@typescript-eslint/no-namespace": "off",
+            "no-inner-declarations": "off",
             "quotes": [
                 "error",
                 "double"
@@ -125,6 +127,9 @@
             ]
         }
     },
+    "eslintIgnore": [
+        "dist"
+    ],
     "prettier": {
         "trailingComma": "all",
         "tabWidth": 4,

--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { cmb, Semigroup } from "@neotype/prelude/cmb.js";
-import { cmp, Eq, eq, le, Ord } from "@neotype/prelude/cmp.js";
+import { cmb, type Semigroup } from "@neotype/prelude/cmb.js";
+import { cmp, eq, le, type Eq, type Ord } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { expect } from "vitest";
 

--- a/src/array.test.ts
+++ b/src/array.test.ts
@@ -18,14 +18,14 @@ import { cmb } from "@neotype/prelude/cmb.js";
 import { cmp, eq, icmp, ieq } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./array.js";
-import "./number.js";
-import "./string.js";
 import {
     expectLawfulEq,
     expectLawfulOrd,
     expectLawfulSemigroup,
 } from "./_test/utils.js";
+import "./array.js";
+import "./number.js";
+import "./string.js";
 
 describe("Array", () => {
     describe("#[Eq.eq]", () => {

--- a/src/array.ts
+++ b/src/array.ts
@@ -66,7 +66,7 @@
  */
 
 import { Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq, icmp, ieq, Ord, type Ordering } from "@neotype/prelude/cmp.js";
+import { Eq, Ord, icmp, ieq, type Ordering } from "@neotype/prelude/cmp.js";
 
 declare global {
     interface Array<T> {

--- a/src/big_int.test.ts
+++ b/src/big_int.test.ts
@@ -1,8 +1,8 @@
-import { cmp, eq, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./big_int.js";
 import { expectLawfulEq, expectLawfulOrd } from "./_test/utils.js";
+import "./big_int.js";
 
 describe("big_int.js", () => {
     describe("BigInt", () => {

--- a/src/big_int64_array.test.ts
+++ b/src/big_int64_array.test.ts
@@ -15,15 +15,15 @@
  */
 
 import { cmb } from "@neotype/prelude/cmb.js";
-import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./big_int64_array.js";
 import {
     expectLawfulEq,
     expectLawfulOrd,
     expectLawfulSemigroup,
 } from "./_test/utils.js";
+import "./big_int64_array.js";
 
 describe("BigInt64Array", () => {
     describe("#[Eq.eq]", () => {

--- a/src/big_int64_array.ts
+++ b/src/big_int64_array.ts
@@ -45,7 +45,7 @@
  */
 
 import { Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+import { Eq, Ord, Ordering, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 
 declare global {
     interface BigInt64Array {

--- a/src/big_uint64_array.test.ts
+++ b/src/big_uint64_array.test.ts
@@ -15,15 +15,15 @@
  */
 
 import { cmb } from "@neotype/prelude/cmb.js";
-import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./big_uint64_array.js";
 import {
     expectLawfulEq,
     expectLawfulOrd,
     expectLawfulSemigroup,
 } from "./_test/utils.js";
+import "./big_uint64_array.js";
 
 describe("BigUint64Array", () => {
     describe("#[Eq.eq]", () => {

--- a/src/big_uint64_array.ts
+++ b/src/big_uint64_array.ts
@@ -45,7 +45,7 @@
  */
 
 import { Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+import { Eq, Ord, Ordering, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 
 declare global {
     interface BigUint64Array {

--- a/src/boolean.test.ts
+++ b/src/boolean.test.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { cmp, eq, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./boolean.js";
 import { expectLawfulEq, expectLawfulOrd } from "./_test/utils.js";
+import "./boolean.js";
 
 describe("Boolean", () => {
     describe("#[Eq.eq]", () => {

--- a/src/date.test.ts
+++ b/src/date.test.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { cmp, eq, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./date.js";
 import { expectLawfulEq, expectLawfulOrd } from "./_test/utils.js";
+import "./date.js";
 
 describe("Date", () => {
     describe("#[Eq.eq]", () => {

--- a/src/float32_array.test.ts
+++ b/src/float32_array.test.ts
@@ -15,15 +15,15 @@
  */
 
 import { cmb } from "@neotype/prelude/cmb.js";
-import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./float32_array.js";
 import {
     expectLawfulEq,
     expectLawfulOrd,
     expectLawfulSemigroup,
 } from "./_test/utils.js";
+import "./float32_array.js";
 
 describe("#[Eq.eq]", () => {
     it("compares the arrays lexicographically", () => {

--- a/src/float32_array.ts
+++ b/src/float32_array.ts
@@ -45,7 +45,7 @@
  */
 
 import { Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+import { Eq, Ord, Ordering, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 
 declare global {
     interface Float32Array {

--- a/src/float64_array.test.ts
+++ b/src/float64_array.test.ts
@@ -15,15 +15,15 @@
  */
 
 import { cmb } from "@neotype/prelude/cmb.js";
-import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./float64_array.js";
 import {
     expectLawfulEq,
     expectLawfulOrd,
     expectLawfulSemigroup,
 } from "./_test/utils.js";
+import "./float64_array.js";
 
 describe("Float64Array", () => {
     describe("#[Eq.eq]", () => {

--- a/src/float64_array.ts
+++ b/src/float64_array.ts
@@ -45,7 +45,7 @@
  */
 
 import { Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+import { Eq, Ord, Ordering, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 
 declare global {
     interface Float64Array {

--- a/src/function.test.ts
+++ b/src/function.test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { cmb, Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq, eq } from "@neotype/prelude/cmp.js";
+import { cmb, type Semigroup } from "@neotype/prelude/cmb.js";
+import { eq, type Eq } from "@neotype/prelude/cmp.js";
 import { id } from "@neotype/prelude/fn.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";

--- a/src/function.ts
+++ b/src/function.ts
@@ -40,7 +40,7 @@
  * @module
  */
 
-import { cmb, Semigroup } from "@neotype/prelude/cmb.js";
+import { Semigroup, cmb } from "@neotype/prelude/cmb.js";
 
 declare global {
     interface Function {

--- a/src/int16_array.test.ts
+++ b/src/int16_array.test.ts
@@ -15,15 +15,15 @@
  */
 
 import { cmb } from "@neotype/prelude/cmb.js";
-import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./int16_array.js";
 import {
     expectLawfulEq,
     expectLawfulOrd,
     expectLawfulSemigroup,
 } from "./_test/utils.js";
+import "./int16_array.js";
 
 describe("Int16Array", () => {
     describe("#[Eq.eq]", () => {

--- a/src/int16_array.ts
+++ b/src/int16_array.ts
@@ -45,7 +45,7 @@
  */
 
 import { Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+import { Eq, Ord, Ordering, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 
 declare global {
     interface Int16Array {

--- a/src/int32_array.test.ts
+++ b/src/int32_array.test.ts
@@ -15,15 +15,15 @@
  */
 
 import { cmb } from "@neotype/prelude/cmb.js";
-import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./int32_array.js";
 import {
     expectLawfulEq,
     expectLawfulOrd,
     expectLawfulSemigroup,
 } from "./_test/utils.js";
+import "./int32_array.js";
 
 describe("Int32Array", () => {
     describe("#[Eq.eq]", () => {

--- a/src/int32_array.ts
+++ b/src/int32_array.ts
@@ -45,7 +45,7 @@
  */
 
 import { Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+import { Eq, Ord, Ordering, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 
 declare global {
     interface Int32Array {

--- a/src/int8_array.test.ts
+++ b/src/int8_array.test.ts
@@ -15,15 +15,15 @@
  */
 
 import { cmb } from "@neotype/prelude/cmb.js";
-import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./int8_array.js";
 import {
     expectLawfulEq,
     expectLawfulOrd,
     expectLawfulSemigroup,
 } from "./_test/utils.js";
+import "./int8_array.js";
 
 describe("Int8Array", () => {
     describe("#[Eq.eq]", () => {

--- a/src/int8_array.ts
+++ b/src/int8_array.ts
@@ -45,7 +45,7 @@
  */
 
 import { Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+import { Eq, Ord, Ordering, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 
 declare global {
     interface Int8Array {

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -18,9 +18,9 @@ import { cmb } from "@neotype/prelude/cmb.js";
 import { eq } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
+import { expectLawfulEq, expectLawfulSemigroup } from "./_test/utils.js";
 import "./map.js";
 import "./string.js";
-import { expectLawfulEq, expectLawfulSemigroup } from "./_test/utils.js";
 
 describe("Map", () => {
     describe("#[Eq.eq]", () => {

--- a/src/number.test.ts
+++ b/src/number.test.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { cmp, eq, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./number.js";
 import { expectLawfulEq, expectLawfulOrd } from "./_test/utils.js";
+import "./number.js";
 
 describe("Number", () => {
     describe("#[Eq.eq]", () => {

--- a/src/promise.ts
+++ b/src/promise.ts
@@ -38,7 +38,7 @@
  * @module
  */
 
-import { cmb, Semigroup } from "@neotype/prelude/cmb.js";
+import { Semigroup, cmb } from "@neotype/prelude/cmb.js";
 
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/set.test.ts
+++ b/src/set.test.ts
@@ -18,8 +18,8 @@ import { cmb } from "@neotype/prelude/cmb.js";
 import { eq } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./set.js";
 import { expectLawfulEq, expectLawfulSemigroup } from "./_test/utils.js";
+import "./set.js";
 
 describe("Set", () => {
     describe("#[Eq.eq]", () => {

--- a/src/string.test.ts
+++ b/src/string.test.ts
@@ -15,15 +15,15 @@
  */
 
 import { cmb } from "@neotype/prelude/cmb.js";
-import { cmp, eq, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./string.js";
 import {
     expectLawfulEq,
     expectLawfulOrd,
     expectLawfulSemigroup,
 } from "./_test/utils.js";
+import "./string.js";
 
 describe("String", () => {
     describe("#[Eq.eq]", () => {

--- a/src/symbol.test.ts
+++ b/src/symbol.test.ts
@@ -17,8 +17,8 @@
 import { eq } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./symbol.js";
 import { expectLawfulEq } from "./_test/utils.js";
+import "./symbol.js";
 
 describe("Symbol", () => {
     describe("#[Eq.eq]", () => {

--- a/src/uint16_array.test.ts
+++ b/src/uint16_array.test.ts
@@ -15,15 +15,15 @@
  */
 
 import { cmb } from "@neotype/prelude/cmb.js";
-import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./uint16_array.js";
 import {
     expectLawfulEq,
     expectLawfulOrd,
     expectLawfulSemigroup,
 } from "./_test/utils.js";
+import "./uint16_array.js";
 
 describe("Uint16Array", () => {
     describe("#[Eq.eq]", () => {

--- a/src/uint16_array.ts
+++ b/src/uint16_array.ts
@@ -45,7 +45,7 @@
  */
 
 import { Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+import { Eq, Ord, Ordering, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 
 declare global {
     interface Uint16Array {

--- a/src/uint32_array.test.ts
+++ b/src/uint32_array.test.ts
@@ -15,15 +15,15 @@
  */
 
 import { cmb } from "@neotype/prelude/cmb.js";
-import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./uint32_array.js";
 import {
     expectLawfulEq,
     expectLawfulOrd,
     expectLawfulSemigroup,
 } from "./_test/utils.js";
+import "./uint32_array.js";
 
 describe("Uint32Array", () => {
     describe("#[Eq.eq]", () => {

--- a/src/uint32_array.ts
+++ b/src/uint32_array.ts
@@ -45,7 +45,7 @@
  */
 
 import { Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+import { Eq, Ord, Ordering, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 
 declare global {
     interface Uint32Array {

--- a/src/uint8_array.test.ts
+++ b/src/uint8_array.test.ts
@@ -15,15 +15,15 @@
  */
 
 import { cmb } from "@neotype/prelude/cmb.js";
-import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./uint8_array.js";
 import {
     expectLawfulEq,
     expectLawfulOrd,
     expectLawfulSemigroup,
 } from "./_test/utils.js";
+import "./uint8_array.js";
 
 describe("uint8_array.js", () => {
     describe("Uint8Array", () => {

--- a/src/uint8_array.ts
+++ b/src/uint8_array.ts
@@ -45,7 +45,7 @@
  */
 
 import { Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+import { Eq, Ord, Ordering, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 
 declare global {
     interface Uint8Array {

--- a/src/uint8_clamped_array.test.ts
+++ b/src/uint8_clamped_array.test.ts
@@ -15,15 +15,15 @@
  */
 
 import { cmb } from "@neotype/prelude/cmb.js";
-import { cmp, eq, icmpBy, ieqBy, Ordering } from "@neotype/prelude/cmp.js";
+import { Ordering, cmp, eq, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import "./uint8_clamped_array.js";
 import {
     expectLawfulEq,
     expectLawfulOrd,
     expectLawfulSemigroup,
 } from "./_test/utils.js";
+import "./uint8_clamped_array.js";
 
 describe("Uint8ClampedArray", () => {
     describe("#[Eq.eq]", () => {

--- a/src/uint8_clamped_array.ts
+++ b/src/uint8_clamped_array.ts
@@ -45,7 +45,7 @@
  */
 
 import { Semigroup } from "@neotype/prelude/cmb.js";
-import { Eq, icmpBy, ieqBy, Ord, Ordering } from "@neotype/prelude/cmp.js";
+import { Eq, Ord, Ordering, icmpBy, ieqBy } from "@neotype/prelude/cmp.js";
 
 declare global {
     interface Uint8ClampedArray {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
         "declarationMap": true,
         "sourceMap": true,
         "outDir": "./dist",
-        "importsNotUsedAsValues": "remove",
         "downlevelIteration": false,
         "esModuleInterop": false,
         "allowSyntheticDefaultImports": false,


### PR DESCRIPTION
- Adopt an updated import sort order.
- Introduce lint rules for type-only import specifiers.
- Add TS 5.0 to the CI test matrix.
- Don't lint the `dist` folder.