### PR TITLE
Tidy up the unit tests

### DIFF
--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -15,58 +15,58 @@
  */
 
 import { cmb, type Semigroup } from "@neotype/prelude/cmb.js";
-import { cmp, eq, le, type Eq, type Ord } from "@neotype/prelude/cmp.js";
+import { eq, le, type Eq, type Ord } from "@neotype/prelude/cmp.js";
 import * as fc from "fast-check";
 import { expect } from "vitest";
 
 export function expectLawfulEq<A extends Eq<A>>(arb: fc.Arbitrary<A>): void {
 	fc.assert(
-		fc.property(arb, (x) => {
-			expect(eq(x, x), "reflexivity").to.be.true;
+		fc.property(arb, (val) => {
+			expect(eq(val, val), "reflexivity").to.be.true;
 		}),
 	);
 
 	fc.assert(
-		fc.property(arb, arb, (x, y) => {
-			expect(eq(x, y), "symmetry").to.equal(eq(y, x));
+		fc.property(arb, arb, (lhs, rhs) => {
+			expect(eq(lhs, rhs), "symmetry").to.equal(eq(rhs, lhs));
 		}),
 	);
 
 	fc.assert(
-		fc.property(arb, (x) => {
-			const y = x,
-				z = x;
-			expect(eq(x, y) && eq(y, z) && eq(x, z), "transitivity").to.be.true;
+		fc.property(arb, arb, arb, (first, second, third) => {
+			if (eq(first, second) && eq(second, third)) {
+				expect(eq(first, third), "transitivity").to.be.true;
+			}
 		}),
 	);
 }
 
 export function expectLawfulOrd<A extends Ord<A>>(arb: fc.Arbitrary<A>): void {
 	fc.assert(
-		fc.property(arb, (x) => {
-			expect(le(x, x), "reflexivity").to.be.true;
+		fc.property(arb, (val) => {
+			expect(le(val, val), "reflexivity").to.be.true;
 		}),
 	);
 
 	fc.assert(
-		fc.property(arb, arb, (x, y) => {
-			expect(le(x, y) && le(y, x), "antisymmetry").to.equal(eq(x, y));
+		fc.property(arb, arb, (lhs, rhs) => {
+			expect(le(lhs, rhs) && le(rhs, lhs), "antisymmetry").to.equal(
+				eq(lhs, rhs),
+			);
 		}),
 	);
 
 	fc.assert(
-		fc.property(arb, arb, arb, (x, y, z) => {
-			const [x1, y1, z1] = [x, y, z].sort((a, b) =>
-				cmp(a, b).toNumber(),
-			) as [A, A, A];
-			expect(le(x1, y1) && le(y1, z1) && le(x1, z1), "transitivity").to.be
-				.true;
+		fc.property(arb, arb, arb, (first, second, third) => {
+			if (le(first, second) && le(second, third)) {
+				expect(le(first, third), "transitivity").to.be.true;
+			}
 		}),
 	);
 
 	fc.assert(
-		fc.property(arb, arb, (x, y) => {
-			expect(le(x, y) || le(y, x), "comparability").to.be.true;
+		fc.property(arb, arb, (lhs, rhs) => {
+			expect(le(lhs, rhs) || le(rhs, lhs), "comparability").to.be.true;
 		}),
 	);
 }
@@ -75,9 +75,14 @@ export function expectLawfulSemigroup<A extends Semigroup<A> & Eq<A>>(
 	arb: fc.Arbitrary<A>,
 ): void {
 	fc.assert(
-		fc.property(arb, arb, arb, (x, y, z) => {
-			expect(eq(cmb(x, cmb(y, z)), cmb(cmb(x, y), z)), "associativity").to
-				.be.true;
+		fc.property(arb, arb, arb, (first, second, third) => {
+			expect(
+				eq(
+					cmb(first, cmb(second, third)),
+					cmb(cmb(first, second), third),
+				),
+				"associativity",
+			).to.be.true;
 		}),
 	);
 }

--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -20,69 +20,60 @@ import * as fc from "fast-check";
 import { expect } from "vitest";
 
 export function expectLawfulEq<A extends Eq<A>>(arb: fc.Arbitrary<A>): void {
-	fc.assert(
-		fc.property(arb, (val) => {
-			expect(eq(val, val), "reflexivity").to.be.true;
-		}),
-	);
+	const reflexivity = fc.property(arb, (val) => {
+		expect(eq(val, val), "reflexivity").to.be.true;
+	});
 
-	fc.assert(
-		fc.property(arb, arb, (lhs, rhs) => {
-			expect(eq(lhs, rhs), "symmetry").to.equal(eq(rhs, lhs));
-		}),
-	);
+	const symmetry = fc.property(arb, arb, (lhs, rhs) => {
+		expect(eq(lhs, rhs), "symmetry").to.equal(eq(rhs, lhs));
+	});
 
-	fc.assert(
-		fc.property(arb, arb, arb, (first, second, third) => {
-			if (eq(first, second) && eq(second, third)) {
-				expect(eq(first, third), "transitivity").to.be.true;
-			}
-		}),
-	);
+	const transitivity = fc.property(arb, arb, arb, (first, second, third) => {
+		if (eq(first, second) && eq(second, third)) {
+			expect(eq(first, third), "transitivity").to.be.true;
+		}
+	});
+
+	fc.assert(reflexivity);
+	fc.assert(symmetry);
+	fc.assert(transitivity);
 }
 
 export function expectLawfulOrd<A extends Ord<A>>(arb: fc.Arbitrary<A>): void {
-	fc.assert(
-		fc.property(arb, (val) => {
-			expect(le(val, val), "reflexivity").to.be.true;
-		}),
-	);
+	const reflexivity = fc.property(arb, (val) => {
+		expect(le(val, val), "reflexivity").to.be.true;
+	});
 
-	fc.assert(
-		fc.property(arb, arb, (lhs, rhs) => {
-			expect(le(lhs, rhs) && le(rhs, lhs), "antisymmetry").to.equal(
-				eq(lhs, rhs),
-			);
-		}),
-	);
+	const antisymmetry = fc.property(arb, arb, (lhs, rhs) => {
+		expect(le(lhs, rhs) && le(rhs, lhs), "antisymmetry").to.equal(
+			eq(lhs, rhs),
+		);
+	});
 
-	fc.assert(
-		fc.property(arb, arb, arb, (first, second, third) => {
-			if (le(first, second) && le(second, third)) {
-				expect(le(first, third), "transitivity").to.be.true;
-			}
-		}),
-	);
+	const transitivity = fc.property(arb, arb, arb, (first, second, third) => {
+		if (le(first, second) && le(second, third)) {
+			expect(le(first, third), "transitivity").to.be.true;
+		}
+	});
 
-	fc.assert(
-		fc.property(arb, arb, (lhs, rhs) => {
-			expect(le(lhs, rhs) || le(rhs, lhs), "comparability").to.be.true;
-		}),
-	);
+	const comparability = fc.property(arb, arb, (lhs, rhs) => {
+		expect(le(lhs, rhs) || le(rhs, lhs), "comparability").to.be.true;
+	});
+
+	fc.assert(reflexivity);
+	fc.assert(antisymmetry);
+	fc.assert(transitivity);
+	fc.assert(comparability);
 }
 
 export function expectLawfulSemigroup<A extends Semigroup<A> & Eq<A>>(
 	arb: fc.Arbitrary<A>,
 ): void {
-	fc.assert(
-		fc.property(arb, arb, arb, (first, second, third) => {
-			expect(
-				eq(
-					cmb(first, cmb(second, third)),
-					cmb(cmb(first, second), third),
-				),
-				"associativity",
-			).to.be.true;
-		}),
-	);
+	const associativity = fc.property(arb, arb, arb, (first, second, third) => {
+		expect(
+			eq(cmb(first, cmb(second, third)), cmb(cmb(first, second), third)),
+			"associativity",
+		).to.be.true;
+	});
+	fc.assert(associativity);
 }

--- a/src/array.test.ts
+++ b/src/array.test.ts
@@ -30,15 +30,14 @@ import "./string.js";
 describe("Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(
-					fc.array(fc.float({ noNaN: true })),
-					fc.array(fc.float({ noNaN: true })),
-					(lhs, rhs) => {
-						expect(eq(lhs, rhs)).to.equal(ieq(lhs, rhs));
-					},
-				),
+			const property = fc.property(
+				fc.array(fc.float({ noNaN: true })),
+				fc.array(fc.float({ noNaN: true })),
+				(lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(ieq(lhs, rhs));
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -48,15 +47,14 @@ describe("Array", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(
-					fc.array(fc.float({ noNaN: true })),
-					fc.array(fc.float({ noNaN: true })),
-					(lhs, rhs) => {
-						expect(cmp(lhs, rhs)).to.equal(icmp(lhs, rhs));
-					},
-				),
+			const property = fc.property(
+				fc.array(fc.float({ noNaN: true })),
+				fc.array(fc.float({ noNaN: true })),
+				(lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(icmp(lhs, rhs));
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -66,15 +64,14 @@ describe("Array", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
-			fc.assert(
-				fc.property(
-					fc.array(fc.anything()),
-					fc.array(fc.anything()),
-					(lhs, rhs) => {
-						expect(cmb(lhs, rhs)).to.deep.equal([...lhs, ...rhs]);
-					},
-				),
+			const property = fc.property(
+				fc.array(fc.anything()),
+				fc.array(fc.anything()),
+				(lhs, rhs) => {
+					expect(cmb(lhs, rhs)).to.deep.equal([...lhs, ...rhs]);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {
@@ -118,21 +115,20 @@ describe("ReadonlyArray", () => {
 describe("tuple literal", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the tuple literals lexicographically", () => {
-			fc.assert(
-				fc.property(
-					fc.float({ noNaN: true }),
-					fc.string(),
-					fc.float({ noNaN: true }),
-					fc.string(),
-					(lhs0, lhs1, rhs0, rhs1) => {
-						const lhs: [number, string] = [lhs0, lhs1];
-						const rhs: [number, string] = [rhs0, rhs1];
-						expect(eq(lhs, rhs)).to.equal(
-							eq(lhs0, rhs0) && eq(lhs1, rhs1),
-						);
-					},
-				),
+			const property = fc.property(
+				fc.float({ noNaN: true }),
+				fc.string(),
+				fc.float({ noNaN: true }),
+				fc.string(),
+				(lhs0, lhs1, rhs0, rhs1) => {
+					const lhs: [number, string] = [lhs0, lhs1];
+					const rhs: [number, string] = [rhs0, rhs1];
+					expect(eq(lhs, rhs)).to.equal(
+						eq(lhs0, rhs0) && eq(lhs1, rhs1),
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -142,21 +138,20 @@ describe("tuple literal", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the tuple literals lexicographically", () => {
-			fc.assert(
-				fc.property(
-					fc.float({ noNaN: true }),
-					fc.string(),
-					fc.float({ noNaN: true }),
-					fc.string(),
-					(lhs0, lhs1, rhs0, rhs1) => {
-						const lhs: [number, string] = [lhs0, lhs1];
-						const rhs: [number, string] = [rhs0, rhs1];
-						expect(cmp(lhs, rhs)).to.equal(
-							cmb(cmp(lhs0, rhs0), cmp(lhs1, rhs1)),
-						);
-					},
-				),
+			const property = fc.property(
+				fc.float({ noNaN: true }),
+				fc.string(),
+				fc.float({ noNaN: true }),
+				fc.string(),
+				(lhs0, lhs1, rhs0, rhs1) => {
+					const lhs: [number, string] = [lhs0, lhs1];
+					const rhs: [number, string] = [rhs0, rhs1];
+					expect(cmp(lhs, rhs)).to.equal(
+						cmb(cmp(lhs0, rhs0), cmp(lhs1, rhs1)),
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {

--- a/src/array.test.ts
+++ b/src/array.test.ts
@@ -34,8 +34,8 @@ describe("Array", () => {
 				fc.property(
 					fc.array(fc.float({ noNaN: true })),
 					fc.array(fc.float({ noNaN: true })),
-					(xs, ys) => {
-						expect(eq(xs, ys)).to.equal(ieq(xs, ys));
+					(lhs, rhs) => {
+						expect(eq(lhs, rhs)).to.equal(ieq(lhs, rhs));
 					},
 				),
 			);
@@ -52,8 +52,8 @@ describe("Array", () => {
 				fc.property(
 					fc.array(fc.float({ noNaN: true })),
 					fc.array(fc.float({ noNaN: true })),
-					(xs, ys) => {
-						expect(cmp(xs, ys)).to.equal(icmp(xs, ys));
+					(lhs, rhs) => {
+						expect(cmp(lhs, rhs)).to.equal(icmp(lhs, rhs));
 					},
 				),
 			);
@@ -70,8 +70,8 @@ describe("Array", () => {
 				fc.property(
 					fc.array(fc.anything()),
 					fc.array(fc.anything()),
-					(xs, ys) => {
-						expect(cmb(xs, ys)).to.deep.equal([...xs, ...ys]);
+					(lhs, rhs) => {
+						expect(cmb(lhs, rhs)).to.deep.equal([...lhs, ...rhs]);
 					},
 				),
 			);
@@ -86,31 +86,31 @@ describe("Array", () => {
 describe("ReadonlyArray", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the readonly array and non-readonly array to each other", () => {
-			const xs: readonly number[] = [];
-			const ys: number[] = [];
-			eq(xs, xs);
-			eq(xs, ys);
-			eq(ys, xs);
+			const readonly: readonly number[] = [];
+			const writable: number[] = [];
+			eq(readonly, readonly);
+			eq(readonly, writable);
+			eq(writable, readonly);
 		});
 	});
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the readonly array and non-readonly array to each other", () => {
-			const xs: readonly number[] = [];
-			const ys: number[] = [];
-			cmp(xs, xs);
-			cmp(xs, ys);
-			cmp(ys, xs);
+			const readonly: readonly number[] = [];
+			const writable: number[] = [];
+			cmp(readonly, readonly);
+			cmp(readonly, writable);
+			cmp(writable, readonly);
 		});
 	});
 
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the readonly array and non-readonly array with each other", () => {
-			const xs: readonly unknown[] = [];
-			const ys: unknown[] = [];
-			cmb(xs, xs);
-			cmb(xs, ys);
-			cmb(ys, xs);
+			const readonly: readonly number[] = [];
+			const writable: number[] = [];
+			cmb(readonly, readonly);
+			cmb(readonly, writable);
+			cmb(writable, readonly);
 		});
 	});
 });
@@ -124,10 +124,12 @@ describe("tuple literal", () => {
 					fc.string(),
 					fc.float({ noNaN: true }),
 					fc.string(),
-					(a, x, b, y) => {
-						const xs: [number, string] = [a, x];
-						const ys: [number, string] = [b, y];
-						expect(eq(xs, ys)).to.equal(eq(a, b) && eq(x, y));
+					(lhs0, lhs1, rhs0, rhs1) => {
+						const lhs: [number, string] = [lhs0, lhs1];
+						const rhs: [number, string] = [rhs0, rhs1];
+						expect(eq(lhs, rhs)).to.equal(
+							eq(lhs0, rhs0) && eq(lhs1, rhs1),
+						);
 					},
 				),
 			);
@@ -146,10 +148,12 @@ describe("tuple literal", () => {
 					fc.string(),
 					fc.float({ noNaN: true }),
 					fc.string(),
-					(a, x, b, y) => {
-						const xs: [number, string] = [a, x];
-						const ys: [number, string] = [b, y];
-						expect(cmp(xs, ys)).to.equal(cmb(cmp(a, b), cmp(x, y)));
+					(lhs0, lhs1, rhs0, rhs1) => {
+						const lhs: [number, string] = [lhs0, lhs1];
+						const rhs: [number, string] = [rhs0, rhs1];
+						expect(cmp(lhs, rhs)).to.equal(
+							cmb(cmp(lhs0, rhs0), cmp(lhs1, rhs1)),
+						);
 					},
 				),
 			);
@@ -164,21 +168,21 @@ describe("tuple literal", () => {
 describe("readonly tuple literal", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the readonly tuple literal and non-readonly tuple literal to each other", () => {
-			const xs: readonly [number, string] = [0, ""];
-			const ys: [number, string] = [0, ""];
-			eq(xs, xs);
-			eq(xs, ys);
-			eq(ys, xs);
+			const readonly: readonly [number, string] = [0, ""];
+			const writable: [number, string] = [0, ""];
+			eq(readonly, readonly);
+			eq(readonly, writable);
+			eq(writable, readonly);
 		});
 	});
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the readonly tuple literal and non-readonly tuple literal to each other", () => {
-			const xs: readonly [number, string] = [0, ""];
-			const ys: [number, string] = [0, ""];
-			cmp(xs, xs);
-			cmp(xs, ys);
-			cmp(ys, xs);
+			const readonly: readonly [number, string] = [0, ""];
+			const writable: [number, string] = [0, ""];
+			cmp(readonly, readonly);
+			cmp(readonly, writable);
+			cmp(writable, readonly);
 		});
 	});
 });

--- a/src/big_int.test.ts
+++ b/src/big_int.test.ts
@@ -9,8 +9,8 @@ describe("big_int.js", () => {
 		describe("#[Eq.eq]", () => {
 			it("compares the bigints strictly", () => {
 				fc.assert(
-					fc.property(fc.bigInt(), fc.bigInt(), (x, y) => {
-						expect(eq(x, y)).to.equal(x === y);
+					fc.property(fc.bigInt(), fc.bigInt(), (lhs, rhs) => {
+						expect(eq(lhs, rhs)).to.equal(lhs === rhs);
 					}),
 				);
 			});
@@ -23,8 +23,10 @@ describe("big_int.js", () => {
 		describe("#[Ord.cmp]", () => {
 			it("compares the bigints as ordered from least to greatest", () => {
 				fc.assert(
-					fc.property(fc.bigInt(), fc.bigInt(), (x, y) => {
-						expect(cmp(x, y)).to.equal(Ordering.fromNumber(x - y));
+					fc.property(fc.bigInt(), fc.bigInt(), (lhs, rhs) => {
+						expect(cmp(lhs, rhs)).to.equal(
+							Ordering.fromNumber(lhs - rhs),
+						);
 					}),
 				);
 			});

--- a/src/big_int.test.ts
+++ b/src/big_int.test.ts
@@ -4,42 +4,40 @@ import { describe, expect, it } from "vitest";
 import { expectLawfulEq, expectLawfulOrd } from "./_test/utils.js";
 import "./big_int.js";
 
-describe("big_int.js", () => {
-	describe("BigInt", () => {
-		describe("#[Eq.eq]", () => {
-			it("compares the bigints strictly", () => {
-				const property = fc.property(
-					fc.bigInt(),
-					fc.bigInt(),
-					(lhs, rhs) => {
-						expect(eq(lhs, rhs)).to.equal(lhs === rhs);
-					},
-				);
-				fc.assert(property);
-			});
-
-			it("implements a lawful equivalence relation", () => {
-				expectLawfulEq(fc.bigInt());
-			});
+describe("BigInt", () => {
+	describe("#[Eq.eq]", () => {
+		it("compares the bigints strictly", () => {
+			const property = fc.property(
+				fc.bigInt(),
+				fc.bigInt(),
+				(lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(lhs === rhs);
+				},
+			);
+			fc.assert(property);
 		});
 
-		describe("#[Ord.cmp]", () => {
-			it("compares the bigints as ordered from least to greatest", () => {
-				const property = fc.property(
-					fc.bigInt(),
-					fc.bigInt(),
-					(lhs, rhs) => {
-						expect(cmp(lhs, rhs)).to.equal(
-							Ordering.fromNumber(lhs - rhs),
-						);
-					},
-				);
-				fc.assert(property);
-			});
+		it("implements a lawful equivalence relation", () => {
+			expectLawfulEq(fc.bigInt());
+		});
+	});
 
-			it("implements a lawful total order", () => {
-				expectLawfulOrd(fc.bigInt());
-			});
+	describe("#[Ord.cmp]", () => {
+		it("compares the bigints as ordered from least to greatest", () => {
+			const property = fc.property(
+				fc.bigInt(),
+				fc.bigInt(),
+				(lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						Ordering.fromNumber(lhs - rhs),
+					);
+				},
+			);
+			fc.assert(property);
+		});
+
+		it("implements a lawful total order", () => {
+			expectLawfulOrd(fc.bigInt());
 		});
 	});
 });

--- a/src/big_int.test.ts
+++ b/src/big_int.test.ts
@@ -8,11 +8,14 @@ describe("big_int.js", () => {
 	describe("BigInt", () => {
 		describe("#[Eq.eq]", () => {
 			it("compares the bigints strictly", () => {
-				fc.assert(
-					fc.property(fc.bigInt(), fc.bigInt(), (lhs, rhs) => {
+				const property = fc.property(
+					fc.bigInt(),
+					fc.bigInt(),
+					(lhs, rhs) => {
 						expect(eq(lhs, rhs)).to.equal(lhs === rhs);
-					}),
+					},
 				);
+				fc.assert(property);
 			});
 
 			it("implements a lawful equivalence relation", () => {
@@ -22,13 +25,16 @@ describe("big_int.js", () => {
 
 		describe("#[Ord.cmp]", () => {
 			it("compares the bigints as ordered from least to greatest", () => {
-				fc.assert(
-					fc.property(fc.bigInt(), fc.bigInt(), (lhs, rhs) => {
+				const property = fc.property(
+					fc.bigInt(),
+					fc.bigInt(),
+					(lhs, rhs) => {
 						expect(cmp(lhs, rhs)).to.equal(
 							Ordering.fromNumber(lhs - rhs),
 						);
-					}),
+					},
 				);
+				fc.assert(property);
 			});
 
 			it("implements a lawful total order", () => {

--- a/src/big_int64_array.test.ts
+++ b/src/big_int64_array.test.ts
@@ -28,21 +28,20 @@ import "./big_int64_array.js";
 describe("BigInt64Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(
-					fc.bigInt64Array(),
-					fc.bigInt64Array(),
-					(lhs, rhs) => {
-						expect(eq(lhs, rhs)).to.equal(
-							ieqBy(
-								lhs,
-								rhs,
-								(lhsElem, rhsElem) => lhsElem === rhsElem,
-							),
-						);
-					},
-				),
+			const property = fc.property(
+				fc.bigInt64Array(),
+				fc.bigInt64Array(),
+				(lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(
+						ieqBy(
+							lhs,
+							rhs,
+							(lhsElem, rhsElem) => lhsElem === rhsElem,
+						),
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -52,19 +51,18 @@ describe("BigInt64Array", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(
-					fc.bigInt64Array(),
-					fc.bigInt64Array(),
-					(lhs, rhs) => {
-						expect(cmp(lhs, rhs)).to.equal(
-							icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
-								Ordering.fromNumber(lhsElem - rhsElem),
-							),
-						);
-					},
-				),
+			const property = fc.property(
+				fc.bigInt64Array(),
+				fc.bigInt64Array(),
+				(lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+							Ordering.fromNumber(lhsElem - rhsElem),
+						),
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -74,23 +72,20 @@ describe("BigInt64Array", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
-			fc.assert(
-				fc.property(
-					fc.bigInt64Array(),
-					fc.bigInt64Array(),
-					(lhs, rhs) => {
-						const result = cmb(lhs, rhs);
+			const property = fc.property(
+				fc.bigInt64Array(),
+				fc.bigInt64Array(),
+				(lhs, rhs) => {
+					const result = cmb(lhs, rhs);
 
-						const expected = new BigInt64Array(
-							lhs.length + rhs.length,
-						);
-						expected.set(lhs);
-						expected.set(rhs, lhs.length);
+					const expected = new BigInt64Array(lhs.length + rhs.length);
+					expected.set(lhs);
+					expected.set(rhs, lhs.length);
 
-						expect(result).to.deep.equal(expected);
-					},
-				),
+					expect(result).to.deep.equal(expected);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/big_int64_array.test.ts
+++ b/src/big_int64_array.test.ts
@@ -32,9 +32,13 @@ describe("BigInt64Array", () => {
 				fc.property(
 					fc.bigInt64Array(),
 					fc.bigInt64Array(),
-					(xs, ys) => {
-						expect(eq(xs, ys)).to.equal(
-							ieqBy(xs, ys, (x, y) => x === y),
+					(lhs, rhs) => {
+						expect(eq(lhs, rhs)).to.equal(
+							ieqBy(
+								lhs,
+								rhs,
+								(lhsElem, rhsElem) => lhsElem === rhsElem,
+							),
 						);
 					},
 				),
@@ -52,10 +56,10 @@ describe("BigInt64Array", () => {
 				fc.property(
 					fc.bigInt64Array(),
 					fc.bigInt64Array(),
-					(xs, ys) => {
-						expect(cmp(xs, ys)).to.equal(
-							icmpBy(xs, ys, (x, y) =>
-								Ordering.fromNumber(x - y),
+					(lhs, rhs) => {
+						expect(cmp(lhs, rhs)).to.equal(
+							icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+								Ordering.fromNumber(lhsElem - rhsElem),
 							),
 						);
 					},
@@ -74,15 +78,16 @@ describe("BigInt64Array", () => {
 				fc.property(
 					fc.bigInt64Array(),
 					fc.bigInt64Array(),
-					(xs, ys) => {
-						const result = cmb(xs, ys);
+					(lhs, rhs) => {
+						const result = cmb(lhs, rhs);
 
-						const exp = new BigInt64Array(xs.length + ys.length);
-						exp.set(xs);
-						exp.set(ys, xs.length);
+						const expected = new BigInt64Array(
+							lhs.length + rhs.length,
+						);
+						expected.set(lhs);
+						expected.set(rhs, lhs.length);
 
-						expect(result).to.deep.equal(exp);
-						expect(exp.length).to.equal(xs.length + ys.length);
+						expect(result).to.deep.equal(expected);
 					},
 				),
 			);

--- a/src/big_uint64_array.test.ts
+++ b/src/big_uint64_array.test.ts
@@ -32,9 +32,13 @@ describe("BigUint64Array", () => {
 				fc.property(
 					fc.bigUint64Array(),
 					fc.bigUint64Array(),
-					(xs, ys) => {
-						expect(eq(xs, ys)).to.equal(
-							ieqBy(xs, ys, (x, y) => x === y),
+					(lhs, rhs) => {
+						expect(eq(lhs, rhs)).to.equal(
+							ieqBy(
+								lhs,
+								rhs,
+								(lhsElem, rhsElem) => lhsElem === rhsElem,
+							),
 						);
 					},
 				),
@@ -52,10 +56,10 @@ describe("BigUint64Array", () => {
 				fc.property(
 					fc.bigUint64Array(),
 					fc.bigUint64Array(),
-					(xs, ys) => {
-						expect(cmp(xs, ys)).to.equal(
-							icmpBy(xs, ys, (x, y) =>
-								Ordering.fromNumber(x - y),
+					(lhs, rhs) => {
+						expect(cmp(lhs, rhs)).to.equal(
+							icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+								Ordering.fromNumber(lhsElem - rhsElem),
 							),
 						);
 					},
@@ -74,15 +78,16 @@ describe("BigUint64Array", () => {
 				fc.property(
 					fc.bigUint64Array(),
 					fc.bigUint64Array(),
-					(xs, ys) => {
-						const result = cmb(xs, ys);
+					(lhs, rhs) => {
+						const result = cmb(lhs, rhs);
 
-						const exp = new BigUint64Array(xs.length + ys.length);
-						exp.set(xs);
-						exp.set(ys, xs.length);
+						const expected = new BigUint64Array(
+							lhs.length + rhs.length,
+						);
+						expected.set(lhs);
+						expected.set(rhs, lhs.length);
 
-						expect(result).to.deep.equal(exp);
-						expect(exp.length).to.equal(xs.length + ys.length);
+						expect(result).to.deep.equal(expected);
 					},
 				),
 			);

--- a/src/big_uint64_array.test.ts
+++ b/src/big_uint64_array.test.ts
@@ -28,21 +28,20 @@ import "./big_uint64_array.js";
 describe("BigUint64Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(
-					fc.bigUint64Array(),
-					fc.bigUint64Array(),
-					(lhs, rhs) => {
-						expect(eq(lhs, rhs)).to.equal(
-							ieqBy(
-								lhs,
-								rhs,
-								(lhsElem, rhsElem) => lhsElem === rhsElem,
-							),
-						);
-					},
-				),
+			const property = fc.property(
+				fc.bigUint64Array(),
+				fc.bigUint64Array(),
+				(lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(
+						ieqBy(
+							lhs,
+							rhs,
+							(lhsElem, rhsElem) => lhsElem === rhsElem,
+						),
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -52,19 +51,18 @@ describe("BigUint64Array", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(
-					fc.bigUint64Array(),
-					fc.bigUint64Array(),
-					(lhs, rhs) => {
-						expect(cmp(lhs, rhs)).to.equal(
-							icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
-								Ordering.fromNumber(lhsElem - rhsElem),
-							),
-						);
-					},
-				),
+			const property = fc.property(
+				fc.bigUint64Array(),
+				fc.bigUint64Array(),
+				(lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+							Ordering.fromNumber(lhsElem - rhsElem),
+						),
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -74,23 +72,22 @@ describe("BigUint64Array", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
-			fc.assert(
-				fc.property(
-					fc.bigUint64Array(),
-					fc.bigUint64Array(),
-					(lhs, rhs) => {
-						const result = cmb(lhs, rhs);
+			const property = fc.property(
+				fc.bigUint64Array(),
+				fc.bigUint64Array(),
+				(lhs, rhs) => {
+					const result = cmb(lhs, rhs);
 
-						const expected = new BigUint64Array(
-							lhs.length + rhs.length,
-						);
-						expected.set(lhs);
-						expected.set(rhs, lhs.length);
+					const expected = new BigUint64Array(
+						lhs.length + rhs.length,
+					);
+					expected.set(lhs);
+					expected.set(rhs, lhs.length);
 
-						expect(result).to.deep.equal(expected);
-					},
-				),
+					expect(result).to.deep.equal(expected);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawfulSemigroup", () => {

--- a/src/boolean.test.ts
+++ b/src/boolean.test.ts
@@ -23,11 +23,14 @@ import "./boolean.js";
 describe("Boolean", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the booleans strictly", () => {
-			fc.assert(
-				fc.property(fc.boolean(), fc.boolean(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.boolean(),
+				fc.boolean(),
+				(lhs, rhs) => {
 					expect(eq(lhs, rhs)).to.equal(lhs === rhs);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -37,13 +40,16 @@ describe("Boolean", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares false as less than true", () => {
-			fc.assert(
-				fc.property(fc.boolean(), fc.boolean(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.boolean(),
+				fc.boolean(),
+				(lhs, rhs) => {
 					expect(cmp(lhs, rhs)).to.equal(
 						Ordering.fromNumber(Number(lhs) - Number(rhs)),
 					);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {

--- a/src/boolean.test.ts
+++ b/src/boolean.test.ts
@@ -24,8 +24,8 @@ describe("Boolean", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the booleans strictly", () => {
 			fc.assert(
-				fc.property(fc.boolean(), fc.boolean(), (x, y) => {
-					expect(eq(x, y)).to.equal(x === y);
+				fc.property(fc.boolean(), fc.boolean(), (lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(lhs === rhs);
 				}),
 			);
 		});
@@ -38,9 +38,9 @@ describe("Boolean", () => {
 	describe("#[Ord.cmp]", () => {
 		it("compares false as less than true", () => {
 			fc.assert(
-				fc.property(fc.boolean(), fc.boolean(), (x, y) => {
-					expect(cmp(x, y)).to.equal(
-						Ordering.fromNumber(Number(x) - Number(y)),
+				fc.property(fc.boolean(), fc.boolean(), (lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						Ordering.fromNumber(Number(lhs) - Number(rhs)),
 					);
 				}),
 			);

--- a/src/date.test.ts
+++ b/src/date.test.ts
@@ -24,8 +24,10 @@ describe("Date", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the dates using their numerical representation", () => {
 			fc.assert(
-				fc.property(fc.date(), fc.date(), (x, y) => {
-					expect(eq(x, y)).to.equal(x.getTime() === y.getTime());
+				fc.property(fc.date(), fc.date(), (lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(
+						lhs.getTime() === rhs.getTime(),
+					);
 				}),
 			);
 		});
@@ -38,9 +40,9 @@ describe("Date", () => {
 	describe("#[Ord.cmp]", () => {
 		it("compares the dates using their numerical representation", () => {
 			fc.assert(
-				fc.property(fc.date(), fc.date(), (x, y) => {
-					expect(cmp(x, y)).to.equal(
-						Ordering.fromNumber(x.getTime() - y.getTime()),
+				fc.property(fc.date(), fc.date(), (lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						Ordering.fromNumber(lhs.getTime() - rhs.getTime()),
 					);
 				}),
 			);

--- a/src/date.test.ts
+++ b/src/date.test.ts
@@ -23,13 +23,10 @@ import "./date.js";
 describe("Date", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the dates using their numerical representation", () => {
-			fc.assert(
-				fc.property(fc.date(), fc.date(), (lhs, rhs) => {
-					expect(eq(lhs, rhs)).to.equal(
-						lhs.getTime() === rhs.getTime(),
-					);
-				}),
-			);
+			const property = fc.property(fc.date(), fc.date(), (lhs, rhs) => {
+				expect(eq(lhs, rhs)).to.equal(lhs.getTime() === rhs.getTime());
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -39,13 +36,12 @@ describe("Date", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the dates using their numerical representation", () => {
-			fc.assert(
-				fc.property(fc.date(), fc.date(), (lhs, rhs) => {
-					expect(cmp(lhs, rhs)).to.equal(
-						Ordering.fromNumber(lhs.getTime() - rhs.getTime()),
-					);
-				}),
-			);
+			const property = fc.property(fc.date(), fc.date(), (lhs, rhs) => {
+				expect(cmp(lhs, rhs)).to.equal(
+					Ordering.fromNumber(lhs.getTime() - rhs.getTime()),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {

--- a/src/float32_array.test.ts
+++ b/src/float32_array.test.ts
@@ -31,9 +31,13 @@ describe("#[Eq.eq]", () => {
 			fc.property(
 				fc.float32Array({ noNaN: true }),
 				fc.float32Array({ noNaN: true }),
-				(xs, ys) => {
-					expect(eq(xs, ys)).to.equal(
-						ieqBy(xs, ys, (x, y) => x === y),
+				(lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(
+						ieqBy(
+							lhs,
+							rhs,
+							(lhsElem, rhsElem) => lhsElem === rhsElem,
+						),
 					);
 				},
 			),
@@ -51,9 +55,11 @@ describe("#[Ord.cmp]", () => {
 			fc.property(
 				fc.float32Array({ noNaN: true }),
 				fc.float32Array({ noNaN: true }),
-				(xs, ys) => {
-					expect(cmp(xs, ys)).to.equal(
-						icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+				(lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+							Ordering.fromNumber(lhsElem - rhsElem),
+						),
 					);
 				},
 			),
@@ -71,15 +77,14 @@ describe("#[Semigroup.cmb]", () => {
 			fc.property(
 				fc.float32Array({ noNaN: true }),
 				fc.float32Array({ noNaN: true }),
-				(xs, ys) => {
-					const result = cmb(xs, ys);
+				(lhs, rhs) => {
+					const result = cmb(lhs, rhs);
 
-					const exp = new Float32Array(xs.length + ys.length);
-					exp.set(xs);
-					exp.set(ys, xs.length);
+					const expected = new Float32Array(lhs.length + rhs.length);
+					expected.set(lhs);
+					expected.set(rhs, lhs.length);
 
-					expect(result).to.deep.equal(exp);
-					expect(exp.length).to.equal(xs.length + ys.length);
+					expect(result).to.deep.equal(expected);
 				},
 			),
 		);

--- a/src/float32_array.test.ts
+++ b/src/float32_array.test.ts
@@ -27,21 +27,16 @@ import "./float32_array.js";
 
 describe("#[Eq.eq]", () => {
 	it("compares the arrays lexicographically", () => {
-		fc.assert(
-			fc.property(
-				fc.float32Array({ noNaN: true }),
-				fc.float32Array({ noNaN: true }),
-				(lhs, rhs) => {
-					expect(eq(lhs, rhs)).to.equal(
-						ieqBy(
-							lhs,
-							rhs,
-							(lhsElem, rhsElem) => lhsElem === rhsElem,
-						),
-					);
-				},
-			),
+		const property = fc.property(
+			fc.float32Array({ noNaN: true }),
+			fc.float32Array({ noNaN: true }),
+			(lhs, rhs) => {
+				expect(eq(lhs, rhs)).to.equal(
+					ieqBy(lhs, rhs, (lhsElem, rhsElem) => lhsElem === rhsElem),
+				);
+			},
 		);
+		fc.assert(property);
 	});
 
 	it("implements a lawful equivalence relation", () => {
@@ -51,19 +46,18 @@ describe("#[Eq.eq]", () => {
 
 describe("#[Ord.cmp]", () => {
 	it("compares the arrays lexicographically", () => {
-		fc.assert(
-			fc.property(
-				fc.float32Array({ noNaN: true }),
-				fc.float32Array({ noNaN: true }),
-				(lhs, rhs) => {
-					expect(cmp(lhs, rhs)).to.equal(
-						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
-							Ordering.fromNumber(lhsElem - rhsElem),
-						),
-					);
-				},
-			),
+		const property = fc.property(
+			fc.float32Array({ noNaN: true }),
+			fc.float32Array({ noNaN: true }),
+			(lhs, rhs) => {
+				expect(cmp(lhs, rhs)).to.equal(
+					icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+						Ordering.fromNumber(lhsElem - rhsElem),
+					),
+				);
+			},
 		);
+		fc.assert(property);
 	});
 
 	it("implements a lawful total order", () => {
@@ -73,21 +67,20 @@ describe("#[Ord.cmp]", () => {
 
 describe("#[Semigroup.cmb]", () => {
 	it("concatenates the arrays", () => {
-		fc.assert(
-			fc.property(
-				fc.float32Array({ noNaN: true }),
-				fc.float32Array({ noNaN: true }),
-				(lhs, rhs) => {
-					const result = cmb(lhs, rhs);
+		const property = fc.property(
+			fc.float32Array({ noNaN: true }),
+			fc.float32Array({ noNaN: true }),
+			(lhs, rhs) => {
+				const result = cmb(lhs, rhs);
 
-					const expected = new Float32Array(lhs.length + rhs.length);
-					expected.set(lhs);
-					expected.set(rhs, lhs.length);
+				const expected = new Float32Array(lhs.length + rhs.length);
+				expected.set(lhs);
+				expected.set(rhs, lhs.length);
 
-					expect(result).to.deep.equal(expected);
-				},
-			),
+				expect(result).to.deep.equal(expected);
+			},
 		);
+		fc.assert(property);
 	});
 
 	it("implements a lawful semigroup", () => {

--- a/src/float32_array.test.ts
+++ b/src/float32_array.test.ts
@@ -25,65 +25,71 @@ import {
 } from "./_test/utils.js";
 import "./float32_array.js";
 
-describe("#[Eq.eq]", () => {
-	it("compares the arrays lexicographically", () => {
-		const property = fc.property(
-			fc.float32Array({ noNaN: true }),
-			fc.float32Array({ noNaN: true }),
-			(lhs, rhs) => {
-				expect(eq(lhs, rhs)).to.equal(
-					ieqBy(lhs, rhs, (lhsElem, rhsElem) => lhsElem === rhsElem),
-				);
-			},
-		);
-		fc.assert(property);
+describe("Float32Array", () => {
+	describe("#[Eq.eq]", () => {
+		it("compares the arrays lexicographically", () => {
+			const property = fc.property(
+				fc.float32Array({ noNaN: true }),
+				fc.float32Array({ noNaN: true }),
+				(lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(
+						ieqBy(
+							lhs,
+							rhs,
+							(lhsElem, rhsElem) => lhsElem === rhsElem,
+						),
+					);
+				},
+			);
+			fc.assert(property);
+		});
+
+		it("implements a lawful equivalence relation", () => {
+			expectLawfulEq(fc.float32Array({ noNaN: true }));
+		});
 	});
 
-	it("implements a lawful equivalence relation", () => {
-		expectLawfulEq(fc.float32Array({ noNaN: true }));
-	});
-});
+	describe("#[Ord.cmp]", () => {
+		it("compares the arrays lexicographically", () => {
+			const property = fc.property(
+				fc.float32Array({ noNaN: true }),
+				fc.float32Array({ noNaN: true }),
+				(lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+							Ordering.fromNumber(lhsElem - rhsElem),
+						),
+					);
+				},
+			);
+			fc.assert(property);
+		});
 
-describe("#[Ord.cmp]", () => {
-	it("compares the arrays lexicographically", () => {
-		const property = fc.property(
-			fc.float32Array({ noNaN: true }),
-			fc.float32Array({ noNaN: true }),
-			(lhs, rhs) => {
-				expect(cmp(lhs, rhs)).to.equal(
-					icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
-						Ordering.fromNumber(lhsElem - rhsElem),
-					),
-				);
-			},
-		);
-		fc.assert(property);
-	});
-
-	it("implements a lawful total order", () => {
-		expectLawfulOrd(fc.float32Array({ noNaN: true }));
-	});
-});
-
-describe("#[Semigroup.cmb]", () => {
-	it("concatenates the arrays", () => {
-		const property = fc.property(
-			fc.float32Array({ noNaN: true }),
-			fc.float32Array({ noNaN: true }),
-			(lhs, rhs) => {
-				const result = cmb(lhs, rhs);
-
-				const expected = new Float32Array(lhs.length + rhs.length);
-				expected.set(lhs);
-				expected.set(rhs, lhs.length);
-
-				expect(result).to.deep.equal(expected);
-			},
-		);
-		fc.assert(property);
+		it("implements a lawful total order", () => {
+			expectLawfulOrd(fc.float32Array({ noNaN: true }));
+		});
 	});
 
-	it("implements a lawful semigroup", () => {
-		expectLawfulSemigroup(fc.float32Array({ noNaN: true }));
+	describe("#[Semigroup.cmb]", () => {
+		it("concatenates the arrays", () => {
+			const property = fc.property(
+				fc.float32Array({ noNaN: true }),
+				fc.float32Array({ noNaN: true }),
+				(lhs, rhs) => {
+					const result = cmb(lhs, rhs);
+
+					const expected = new Float32Array(lhs.length + rhs.length);
+					expected.set(lhs);
+					expected.set(rhs, lhs.length);
+
+					expect(result).to.deep.equal(expected);
+				},
+			);
+			fc.assert(property);
+		});
+
+		it("implements a lawful semigroup", () => {
+			expectLawfulSemigroup(fc.float32Array({ noNaN: true }));
+		});
 	});
 });

--- a/src/float64_array.test.ts
+++ b/src/float64_array.test.ts
@@ -28,21 +28,20 @@ import "./float64_array.js";
 describe("Float64Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(
-					fc.float64Array({ noNaN: true }),
-					fc.float64Array({ noNaN: true }),
-					(lhs, rhs) => {
-						expect(eq(lhs, rhs)).to.equal(
-							ieqBy(
-								lhs,
-								rhs,
-								(lhsElem, rhsElem) => lhsElem === rhsElem,
-							),
-						);
-					},
-				),
+			const property = fc.property(
+				fc.float64Array({ noNaN: true }),
+				fc.float64Array({ noNaN: true }),
+				(lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(
+						ieqBy(
+							lhs,
+							rhs,
+							(lhsElem, rhsElem) => lhsElem === rhsElem,
+						),
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -52,19 +51,18 @@ describe("Float64Array", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(
-					fc.float64Array({ noNaN: true }),
-					fc.float64Array({ noNaN: true }),
-					(lhs, rhs) => {
-						expect(cmp(lhs, rhs)).to.equal(
-							icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
-								Ordering.fromNumber(lhsElem - rhsElem),
-							),
-						);
-					},
-				),
+			const property = fc.property(
+				fc.float64Array({ noNaN: true }),
+				fc.float64Array({ noNaN: true }),
+				(lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+							Ordering.fromNumber(lhsElem - rhsElem),
+						),
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -74,23 +72,20 @@ describe("Float64Array", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
-			fc.assert(
-				fc.property(
-					fc.float64Array({ noNaN: true }),
-					fc.float64Array({ noNaN: true }),
-					(lhs, rhs) => {
-						const result = cmb(lhs, rhs);
+			const property = fc.property(
+				fc.float64Array({ noNaN: true }),
+				fc.float64Array({ noNaN: true }),
+				(lhs, rhs) => {
+					const result = cmb(lhs, rhs);
 
-						const expected = new Float64Array(
-							lhs.length + rhs.length,
-						);
-						expected.set(lhs);
-						expected.set(rhs, lhs.length);
+					const expected = new Float64Array(lhs.length + rhs.length);
+					expected.set(lhs);
+					expected.set(rhs, lhs.length);
 
-						expect(result).to.deep.equal(expected);
-					},
-				),
+					expect(result).to.deep.equal(expected);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/float64_array.test.ts
+++ b/src/float64_array.test.ts
@@ -32,9 +32,13 @@ describe("Float64Array", () => {
 				fc.property(
 					fc.float64Array({ noNaN: true }),
 					fc.float64Array({ noNaN: true }),
-					(xs, ys) => {
-						expect(eq(xs, ys)).to.equal(
-							ieqBy(xs, ys, (x, y) => x === y),
+					(lhs, rhs) => {
+						expect(eq(lhs, rhs)).to.equal(
+							ieqBy(
+								lhs,
+								rhs,
+								(lhsElem, rhsElem) => lhsElem === rhsElem,
+							),
 						);
 					},
 				),
@@ -52,10 +56,10 @@ describe("Float64Array", () => {
 				fc.property(
 					fc.float64Array({ noNaN: true }),
 					fc.float64Array({ noNaN: true }),
-					(xs, ys) => {
-						expect(cmp(xs, ys)).to.equal(
-							icmpBy(xs, ys, (x, y) =>
-								Ordering.fromNumber(x - y),
+					(lhs, rhs) => {
+						expect(cmp(lhs, rhs)).to.equal(
+							icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+								Ordering.fromNumber(lhsElem - rhsElem),
 							),
 						);
 					},
@@ -74,15 +78,16 @@ describe("Float64Array", () => {
 				fc.property(
 					fc.float64Array({ noNaN: true }),
 					fc.float64Array({ noNaN: true }),
-					(xs, ys) => {
-						const result = cmb(xs, ys);
+					(lhs, rhs) => {
+						const result = cmb(lhs, rhs);
 
-						const exp = new Float64Array(xs.length + ys.length);
-						exp.set(xs);
-						exp.set(ys, xs.length);
+						const expected = new Float64Array(
+							lhs.length + rhs.length,
+						);
+						expected.set(lhs);
+						expected.set(rhs, lhs.length);
 
-						expect(result).to.deep.equal(exp);
-						expect(exp.length).to.equal(xs.length + ys.length);
+						expect(result).to.deep.equal(expected);
 					},
 				),
 			);

--- a/src/function.test.ts
+++ b/src/function.test.ts
@@ -25,13 +25,12 @@ import "./string.js";
 describe("Function", () => {
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the function results", () => {
-			fc.assert(
-				fc.property(fc.string(), (val) => {
-					const f = cmb(id<string>, id);
-					const result = f(val);
-					expect(result).to.equal(cmb(val, val));
-				}),
-			);
+			const property = fc.property(fc.string(), (val) => {
+				const f = cmb(id<string>, id);
+				const result = f(val);
+				expect(result).to.equal(cmb(val, val));
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {
@@ -39,16 +38,15 @@ describe("Function", () => {
 				A extends Semigroup<A> & Eq<A>,
 			>(arb: fc.Arbitrary<A>): void {
 				type Id<in out A> = (val: A) => A;
-				fc.assert(
-					fc.property(arb, (val) => {
-						expect(
-							eq(
-								cmb<Id<A>>(id, cmb(id, id))(val),
-								cmb<Id<A>>(cmb(id, id), id)(val),
-							),
-						).to.be.true;
-					}),
-				);
+				const property = fc.property(arb, (val) => {
+					expect(
+						eq(
+							cmb<Id<A>>(id, cmb(id, id))(val),
+							cmb<Id<A>>(cmb(id, id), id)(val),
+						),
+					).to.be.true;
+				});
+				fc.assert(property);
 			}
 
 			expectLawfulFunctionSemigroup(fc.string());

--- a/src/function.test.ts
+++ b/src/function.test.ts
@@ -26,10 +26,10 @@ describe("Function", () => {
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the function results", () => {
 			fc.assert(
-				fc.property(fc.string(), (x) => {
+				fc.property(fc.string(), (val) => {
 					const f = cmb(id<string>, id);
-					const result = f(x);
-					expect(result).to.equal(cmb(x, x));
+					const result = f(val);
+					expect(result).to.equal(cmb(val, val));
 				}),
 			);
 		});
@@ -38,13 +38,13 @@ describe("Function", () => {
 			function expectLawfulFunctionSemigroup<
 				A extends Semigroup<A> & Eq<A>,
 			>(arb: fc.Arbitrary<A>): void {
-				type Id<in out A> = (x: A) => A;
+				type Id<in out A> = (val: A) => A;
 				fc.assert(
-					fc.property(arb, (x) => {
+					fc.property(arb, (val) => {
 						expect(
 							eq(
-								cmb<Id<A>>(id, cmb(id, id))(x),
-								cmb<Id<A>>(cmb(id, id), id)(x),
+								cmb<Id<A>>(id, cmb(id, id))(val),
+								cmb<Id<A>>(cmb(id, id), id)(val),
 							),
 						).to.be.true;
 					}),

--- a/src/int16_array.test.ts
+++ b/src/int16_array.test.ts
@@ -28,8 +28,10 @@ import "./int16_array.js";
 describe("Int16Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(fc.int16Array(), fc.int16Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.int16Array(),
+				fc.int16Array(),
+				(lhs, rhs) => {
 					expect(eq(lhs, rhs)).to.equal(
 						ieqBy(
 							lhs,
@@ -37,8 +39,9 @@ describe("Int16Array", () => {
 							(lhsElem, rhsElem) => lhsElem === rhsElem,
 						),
 					);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -48,15 +51,18 @@ describe("Int16Array", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(fc.int16Array(), fc.int16Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.int16Array(),
+				fc.int16Array(),
+				(lhs, rhs) => {
 					expect(cmp(lhs, rhs)).to.equal(
 						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
 							Ordering.fromNumber(lhsElem - rhsElem),
 						),
 					);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -66,8 +72,10 @@ describe("Int16Array", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
-			fc.assert(
-				fc.property(fc.int16Array(), fc.int16Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.int16Array(),
+				fc.int16Array(),
+				(lhs, rhs) => {
 					const result = cmb(lhs, rhs);
 
 					const expected = new Int16Array(lhs.length + rhs.length);
@@ -75,8 +83,9 @@ describe("Int16Array", () => {
 					expected.set(rhs, lhs.length);
 
 					expect(result).to.deep.equal(expected);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/int16_array.test.ts
+++ b/src/int16_array.test.ts
@@ -29,9 +29,13 @@ describe("Int16Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
 			fc.assert(
-				fc.property(fc.int16Array(), fc.int16Array(), (xs, ys) => {
-					expect(eq(xs, ys)).to.equal(
-						ieqBy(xs, ys, (x, y) => x === y),
+				fc.property(fc.int16Array(), fc.int16Array(), (lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(
+						ieqBy(
+							lhs,
+							rhs,
+							(lhsElem, rhsElem) => lhsElem === rhsElem,
+						),
 					);
 				}),
 			);
@@ -45,9 +49,11 @@ describe("Int16Array", () => {
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
 			fc.assert(
-				fc.property(fc.int16Array(), fc.int16Array(), (xs, ys) => {
-					expect(cmp(xs, ys)).to.equal(
-						icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+				fc.property(fc.int16Array(), fc.int16Array(), (lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+							Ordering.fromNumber(lhsElem - rhsElem),
+						),
 					);
 				}),
 			);
@@ -61,15 +67,14 @@ describe("Int16Array", () => {
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
 			fc.assert(
-				fc.property(fc.int16Array(), fc.int16Array(), (xs, ys) => {
-					const result = cmb(xs, ys);
+				fc.property(fc.int16Array(), fc.int16Array(), (lhs, rhs) => {
+					const result = cmb(lhs, rhs);
 
-					const exp = new Int16Array(xs.length + ys.length);
-					exp.set(xs);
-					exp.set(ys, xs.length);
+					const expected = new Int16Array(lhs.length + rhs.length);
+					expected.set(lhs);
+					expected.set(rhs, lhs.length);
 
-					expect(result).to.deep.equal(exp);
-					expect(exp.length).to.equal(xs.length + ys.length);
+					expect(result).to.deep.equal(expected);
 				}),
 			);
 		});

--- a/src/int32_array.test.ts
+++ b/src/int32_array.test.ts
@@ -29,9 +29,13 @@ describe("Int32Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
 			fc.assert(
-				fc.property(fc.int32Array(), fc.int32Array(), (xs, ys) => {
-					expect(eq(xs, ys)).to.equal(
-						ieqBy(xs, ys, (x, y) => x === y),
+				fc.property(fc.int32Array(), fc.int32Array(), (lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(
+						ieqBy(
+							lhs,
+							rhs,
+							(lhsElem, rhsElem) => lhsElem === rhsElem,
+						),
 					);
 				}),
 			);
@@ -45,9 +49,11 @@ describe("Int32Array", () => {
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
 			fc.assert(
-				fc.property(fc.int32Array(), fc.int32Array(), (xs, ys) => {
-					expect(cmp(xs, ys)).to.equal(
-						icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+				fc.property(fc.int32Array(), fc.int32Array(), (lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+							Ordering.fromNumber(lhsElem - rhsElem),
+						),
 					);
 				}),
 			);
@@ -61,15 +67,14 @@ describe("Int32Array", () => {
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
 			fc.assert(
-				fc.property(fc.int32Array(), fc.int32Array(), (xs, ys) => {
-					const result = cmb(xs, ys);
+				fc.property(fc.int32Array(), fc.int32Array(), (lhs, rhs) => {
+					const result = cmb(lhs, rhs);
 
-					const exp = new Int32Array(xs.length + ys.length);
-					exp.set(xs);
-					exp.set(ys, xs.length);
+					const expected = new Int32Array(lhs.length + rhs.length);
+					expected.set(lhs);
+					expected.set(rhs, lhs.length);
 
-					expect(result).to.deep.equal(exp);
-					expect(exp.length).to.equal(xs.length + ys.length);
+					expect(result).to.deep.equal(expected);
 				}),
 			);
 		});

--- a/src/int32_array.test.ts
+++ b/src/int32_array.test.ts
@@ -28,8 +28,10 @@ import "./int32_array.js";
 describe("Int32Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(fc.int32Array(), fc.int32Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.int32Array(),
+				fc.int32Array(),
+				(lhs, rhs) => {
 					expect(eq(lhs, rhs)).to.equal(
 						ieqBy(
 							lhs,
@@ -37,8 +39,9 @@ describe("Int32Array", () => {
 							(lhsElem, rhsElem) => lhsElem === rhsElem,
 						),
 					);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -48,15 +51,18 @@ describe("Int32Array", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(fc.int32Array(), fc.int32Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.int32Array(),
+				fc.int32Array(),
+				(lhs, rhs) => {
 					expect(cmp(lhs, rhs)).to.equal(
 						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
 							Ordering.fromNumber(lhsElem - rhsElem),
 						),
 					);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -66,8 +72,10 @@ describe("Int32Array", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
-			fc.assert(
-				fc.property(fc.int32Array(), fc.int32Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.int32Array(),
+				fc.int32Array(),
+				(lhs, rhs) => {
 					const result = cmb(lhs, rhs);
 
 					const expected = new Int32Array(lhs.length + rhs.length);
@@ -75,8 +83,9 @@ describe("Int32Array", () => {
 					expected.set(rhs, lhs.length);
 
 					expect(result).to.deep.equal(expected);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/int8_array.test.ts
+++ b/src/int8_array.test.ts
@@ -29,9 +29,13 @@ describe("Int8Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
 			fc.assert(
-				fc.property(fc.int8Array(), fc.int8Array(), (xs, ys) => {
-					expect(eq(xs, ys)).to.equal(
-						ieqBy(xs, ys, (x, y) => x === y),
+				fc.property(fc.int8Array(), fc.int8Array(), (lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(
+						ieqBy(
+							lhs,
+							rhs,
+							(lhsElem, rhsElem) => lhsElem === rhsElem,
+						),
 					);
 				}),
 			);
@@ -45,9 +49,11 @@ describe("Int8Array", () => {
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
 			fc.assert(
-				fc.property(fc.int8Array(), fc.int8Array(), (xs, ys) => {
-					expect(cmp(xs, ys)).to.equal(
-						icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+				fc.property(fc.int8Array(), fc.int8Array(), (lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+							Ordering.fromNumber(lhsElem - rhsElem),
+						),
 					);
 				}),
 			);
@@ -61,15 +67,14 @@ describe("Int8Array", () => {
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
 			fc.assert(
-				fc.property(fc.int8Array(), fc.int8Array(), (xs, ys) => {
-					const result = cmb(xs, ys);
+				fc.property(fc.int8Array(), fc.int8Array(), (lhs, rhs) => {
+					const result = cmb(lhs, rhs);
 
-					const exp = new Int8Array(xs.length + ys.length);
-					exp.set(xs);
-					exp.set(ys, xs.length);
+					const expected = new Int8Array(lhs.length + rhs.length);
+					expected.set(lhs);
+					expected.set(rhs, lhs.length);
 
-					expect(result).to.deep.equal(exp);
-					expect(exp.length).to.equal(xs.length + ys.length);
+					expect(result).to.deep.equal(expected);
 				}),
 			);
 		});

--- a/src/int8_array.test.ts
+++ b/src/int8_array.test.ts
@@ -28,8 +28,10 @@ import "./int8_array.js";
 describe("Int8Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(fc.int8Array(), fc.int8Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.int8Array(),
+				fc.int8Array(),
+				(lhs, rhs) => {
 					expect(eq(lhs, rhs)).to.equal(
 						ieqBy(
 							lhs,
@@ -37,8 +39,9 @@ describe("Int8Array", () => {
 							(lhsElem, rhsElem) => lhsElem === rhsElem,
 						),
 					);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -48,15 +51,18 @@ describe("Int8Array", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(fc.int8Array(), fc.int8Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.int8Array(),
+				fc.int8Array(),
+				(lhs, rhs) => {
 					expect(cmp(lhs, rhs)).to.equal(
 						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
 							Ordering.fromNumber(lhsElem - rhsElem),
 						),
 					);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -66,8 +72,10 @@ describe("Int8Array", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
-			fc.assert(
-				fc.property(fc.int8Array(), fc.int8Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.int8Array(),
+				fc.int8Array(),
+				(lhs, rhs) => {
 					const result = cmb(lhs, rhs);
 
 					const expected = new Int8Array(lhs.length + rhs.length);
@@ -75,8 +83,9 @@ describe("Int8Array", () => {
 					expected.set(rhs, lhs.length);
 
 					expect(result).to.deep.equal(expected);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -33,23 +33,23 @@ describe("Map", () => {
 					fc
 						.uniqueArray(fc.tuple(fc.anything(), fc.string()))
 						.map((entries) => new Map(entries)),
-					(xs, ys) => {
-						const result = eq(xs, ys);
+					(lhs, rhs) => {
+						const result = eq(lhs, rhs);
 
-						const exp = (() => {
-							if (xs.size !== ys.size) {
+						const expected = (() => {
+							if (lhs.size !== rhs.size) {
 								return false;
 							}
-							for (const [kx, x] of xs.entries()) {
+							for (const [key, val] of lhs.entries()) {
 								// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-								if (!(ys.has(kx) && eq(ys.get(kx)!, x))) {
+								if (!(rhs.has(key) && eq(rhs.get(key)!, val))) {
 									return false;
 								}
 							}
 							return true;
 						})();
 
-						expect(result).to.equal(exp);
+						expect(result).to.equal(expected);
 					},
 				),
 			);
@@ -74,14 +74,14 @@ describe("Map", () => {
 					fc
 						.uniqueArray(fc.tuple(fc.anything(), fc.anything()))
 						.map((entries) => new Map(entries)),
-					(xs, ys) => {
-						const result = cmb(xs, ys);
-						const exp = new Map([...xs, ...ys]);
+					(lhs, rhs) => {
+						const result = cmb(lhs, rhs);
+						const expected = new Map([...lhs, ...rhs]);
 
-						expect(result.size).to.equal(exp.size);
-						for (const [kx, x] of result) {
-							expect(exp.has(kx)).to.be.true;
-							expect(exp.get(kx)).to.deep.equal(x);
+						expect(result.size).to.equal(expected.size);
+						for (const [key, val] of result) {
+							expect(expected.has(key)).to.be.true;
+							expect(expected.get(key)).to.deep.equal(val);
 						}
 					},
 				),
@@ -101,21 +101,21 @@ describe("Map", () => {
 describe("ReadonlyMap", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the readonly map and non-readonly map to each other", () => {
-			const xs: ReadonlyMap<unknown, string> = new Map();
-			const ys: Map<unknown, string> = new Map();
-			eq(xs, xs);
-			eq(xs, ys);
-			eq(ys, xs);
+			const readonly: ReadonlyMap<unknown, string> = new Map();
+			const writable: Map<unknown, string> = new Map();
+			eq(readonly, readonly);
+			eq(readonly, writable);
+			eq(writable, readonly);
 		});
 	});
 
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the readonly map and non-readonly map with each other", () => {
-			const xs: ReadonlyMap<unknown, unknown> = new Map();
-			const ys: Map<unknown, unknown> = new Map();
-			cmb(xs, xs);
-			cmb(xs, ys);
-			cmb(ys, xs);
+			const readonly: ReadonlyMap<unknown, unknown> = new Map();
+			const writable: Map<unknown, unknown> = new Map();
+			cmb(readonly, readonly);
+			cmb(readonly, writable);
+			cmb(writable, readonly);
 		});
 	});
 });

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -25,34 +25,33 @@ import "./string.js";
 describe("Map", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the keys strictly and compares the values using their Eq implementation", () => {
-			fc.assert(
-				fc.property(
-					fc
-						.uniqueArray(fc.tuple(fc.anything(), fc.string()))
-						.map((entries) => new Map(entries)),
-					fc
-						.uniqueArray(fc.tuple(fc.anything(), fc.string()))
-						.map((entries) => new Map(entries)),
-					(lhs, rhs) => {
-						const result = eq(lhs, rhs);
+			const property = fc.property(
+				fc
+					.uniqueArray(fc.tuple(fc.anything(), fc.string()))
+					.map((entries) => new Map(entries)),
+				fc
+					.uniqueArray(fc.tuple(fc.anything(), fc.string()))
+					.map((entries) => new Map(entries)),
+				(lhs, rhs) => {
+					const result = eq(lhs, rhs);
 
-						const expected = (() => {
-							if (lhs.size !== rhs.size) {
+					const expected = (() => {
+						if (lhs.size !== rhs.size) {
+							return false;
+						}
+						for (const [key, val] of lhs.entries()) {
+							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+							if (!(rhs.has(key) && eq(rhs.get(key)!, val))) {
 								return false;
 							}
-							for (const [key, val] of lhs.entries()) {
-								// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-								if (!(rhs.has(key) && eq(rhs.get(key)!, val))) {
-									return false;
-								}
-							}
-							return true;
-						})();
+						}
+						return true;
+					})();
 
-						expect(result).to.equal(expected);
-					},
-				),
+					expect(result).to.equal(expected);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -66,26 +65,25 @@ describe("Map", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("takes the union of the maps", () => {
-			fc.assert(
-				fc.property(
-					fc
-						.uniqueArray(fc.tuple(fc.anything(), fc.anything()))
-						.map((entries) => new Map(entries)),
-					fc
-						.uniqueArray(fc.tuple(fc.anything(), fc.anything()))
-						.map((entries) => new Map(entries)),
-					(lhs, rhs) => {
-						const result = cmb(lhs, rhs);
-						const expected = new Map([...lhs, ...rhs]);
+			const property = fc.property(
+				fc
+					.uniqueArray(fc.tuple(fc.anything(), fc.anything()))
+					.map((entries) => new Map(entries)),
+				fc
+					.uniqueArray(fc.tuple(fc.anything(), fc.anything()))
+					.map((entries) => new Map(entries)),
+				(lhs, rhs) => {
+					const result = cmb(lhs, rhs);
+					const expected = new Map([...lhs, ...rhs]);
 
-						expect(result.size).to.equal(expected.size);
-						for (const [key, val] of result) {
-							expect(expected.has(key)).to.be.true;
-							expect(expected.get(key)).to.deep.equal(val);
-						}
-					},
-				),
+					expect(result.size).to.equal(expected.size);
+					for (const [key, val] of result) {
+						expect(expected.has(key)).to.be.true;
+						expect(expected.get(key)).to.deep.equal(val);
+					}
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/number.test.ts
+++ b/src/number.test.ts
@@ -23,15 +23,14 @@ import "./number.js";
 describe("Number", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the numbers strictly", () => {
-			fc.assert(
-				fc.property(
-					fc.float({ noNaN: true }),
-					fc.float({ noNaN: true }),
-					(lhs, rhs) => {
-						expect(eq(lhs, rhs)).to.equal(lhs === rhs);
-					},
-				),
+			const property = fc.property(
+				fc.float({ noNaN: true }),
+				fc.float({ noNaN: true }),
+				(lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(lhs === rhs);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -41,17 +40,16 @@ describe("Number", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the numbers as ordered from least to greatest", () => {
-			fc.assert(
-				fc.property(
-					fc.float({ noNaN: true }),
-					fc.float({ noNaN: true }),
-					(lhs, rhs) => {
-						expect(cmp(lhs, rhs)).to.equal(
-							Ordering.fromNumber(lhs - rhs),
-						);
-					},
-				),
+			const property = fc.property(
+				fc.float({ noNaN: true }),
+				fc.float({ noNaN: true }),
+				(lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						Ordering.fromNumber(lhs - rhs),
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {

--- a/src/number.test.ts
+++ b/src/number.test.ts
@@ -27,8 +27,8 @@ describe("Number", () => {
 				fc.property(
 					fc.float({ noNaN: true }),
 					fc.float({ noNaN: true }),
-					(x, y) => {
-						expect(eq(x, y)).to.equal(x === y);
+					(lhs, rhs) => {
+						expect(eq(lhs, rhs)).to.equal(lhs === rhs);
 					},
 				),
 			);
@@ -45,8 +45,10 @@ describe("Number", () => {
 				fc.property(
 					fc.float({ noNaN: true }),
 					fc.float({ noNaN: true }),
-					(x, y) => {
-						expect(cmp(x, y)).to.equal(Ordering.fromNumber(x - y));
+					(lhs, rhs) => {
+						expect(cmp(lhs, rhs)).to.equal(
+							Ordering.fromNumber(lhs - rhs),
+						);
 					},
 				),
 			);

--- a/src/promise.test.ts
+++ b/src/promise.test.ts
@@ -24,33 +24,35 @@ import "./string.js";
 describe("Promise", () => {
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the fulfilled results", async () => {
-			await fc.assert(
-				fc.asyncProperty(fc.string(), fc.string(), async (lhs, rhs) => {
+			const property = fc.asyncProperty(
+				fc.string(),
+				fc.string(),
+				async (lhs, rhs) => {
 					const result = await cmb(
 						Promise.resolve(lhs),
 						Promise.resolve(rhs),
 					);
 					expect(result).to.equal(cmb(lhs, rhs));
-				}),
+				},
 			);
+			await fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", async () => {
 			async function expectLawfulPromiseSemigroup<
 				A extends Semigroup<A> & Eq<A>,
 			>(arb: fc.Arbitrary<Promise<A>>): Promise<void> {
-				await fc.assert(
-					fc.asyncProperty(
-						arb,
-						arb,
-						arb,
-						async (first, second, third) => {
-							const t0 = await cmb(first, cmb(second, third));
-							const t1 = await cmb(cmb(first, second), third);
-							expect(eq(t0, t1)).to.be.true;
-						},
-					),
+				const property = fc.asyncProperty(
+					arb,
+					arb,
+					arb,
+					async (first, second, third) => {
+						const t0 = await cmb(first, cmb(second, third));
+						const t1 = await cmb(cmb(first, second), third);
+						expect(eq(t0, t1)).to.be.true;
+					},
 				);
+				await fc.assert(property);
 			}
 
 			await expectLawfulPromiseSemigroup(

--- a/src/promise.test.ts
+++ b/src/promise.test.ts
@@ -25,12 +25,12 @@ describe("Promise", () => {
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the fulfilled results", async () => {
 			await fc.assert(
-				fc.asyncProperty(fc.string(), fc.string(), async (x, y) => {
+				fc.asyncProperty(fc.string(), fc.string(), async (lhs, rhs) => {
 					const result = await cmb(
-						Promise.resolve(x),
-						Promise.resolve(y),
+						Promise.resolve(lhs),
+						Promise.resolve(rhs),
 					);
-					expect(result).to.equal(cmb(x, y));
+					expect(result).to.equal(cmb(lhs, rhs));
 				}),
 			);
 		});
@@ -40,16 +40,21 @@ describe("Promise", () => {
 				A extends Semigroup<A> & Eq<A>,
 			>(arb: fc.Arbitrary<Promise<A>>): Promise<void> {
 				await fc.assert(
-					fc.asyncProperty(arb, arb, arb, async (x, y, z) => {
-						const t0 = await cmb(x, cmb(y, z));
-						const t1 = await cmb(cmb(x, y), z);
-						expect(eq(t0, t1)).to.be.true;
-					}),
+					fc.asyncProperty(
+						arb,
+						arb,
+						arb,
+						async (first, second, third) => {
+							const t0 = await cmb(first, cmb(second, third));
+							const t1 = await cmb(cmb(first, second), third);
+							expect(eq(t0, t1)).to.be.true;
+						},
+					),
 				);
 			}
 
 			await expectLawfulPromiseSemigroup(
-				fc.string().map((x) => Promise.resolve(x)),
+				fc.string().map((val) => Promise.resolve(val)),
 			);
 		});
 	});

--- a/src/set.test.ts
+++ b/src/set.test.ts
@@ -24,33 +24,28 @@ import "./set.js";
 describe("Set", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the elements strictly", () => {
-			fc.assert(
-				fc.property(
-					fc
-						.uniqueArray(fc.anything())
-						.map((elems) => new Set(elems)),
-					fc
-						.uniqueArray(fc.anything())
-						.map((elems) => new Set(elems)),
-					(lhs, rhs) => {
-						const result = eq(lhs, rhs);
+			const property = fc.property(
+				fc.uniqueArray(fc.anything()).map((elems) => new Set(elems)),
+				fc.uniqueArray(fc.anything()).map((elems) => new Set(elems)),
+				(lhs, rhs) => {
+					const result = eq(lhs, rhs);
 
-						const expected = (() => {
-							if (lhs.size !== rhs.size) {
+					const expected = (() => {
+						if (lhs.size !== rhs.size) {
+							return false;
+						}
+						for (const val of lhs) {
+							if (!rhs.has(val)) {
 								return false;
 							}
-							for (const val of lhs) {
-								if (!rhs.has(val)) {
-									return false;
-								}
-							}
-							return true;
-						})();
+						}
+						return true;
+					})();
 
-						expect(result).to.equal(expected);
-					},
-				),
+					expect(result).to.equal(expected);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -62,25 +57,20 @@ describe("Set", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("takes the union of the sets", () => {
-			fc.assert(
-				fc.property(
-					fc
-						.uniqueArray(fc.anything())
-						.map((elems) => new Set(elems)),
-					fc
-						.uniqueArray(fc.anything())
-						.map((elems) => new Set(elems)),
-					(lhs, rhs) => {
-						const result = cmb(lhs, rhs);
-						const expected = new Set([...lhs, ...rhs]);
+			const property = fc.property(
+				fc.uniqueArray(fc.anything()).map((elems) => new Set(elems)),
+				fc.uniqueArray(fc.anything()).map((elems) => new Set(elems)),
+				(lhs, rhs) => {
+					const result = cmb(lhs, rhs);
+					const expected = new Set([...lhs, ...rhs]);
 
-						expect(result.size).to.equal(expected.size);
-						for (const val of result) {
-							expect(expected.has(val)).to.be.true;
-						}
-					},
-				),
+					expect(result.size).to.equal(expected.size);
+					for (const val of result) {
+						expect(expected.has(val)).to.be.true;
+					}
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/set.test.ts
+++ b/src/set.test.ts
@@ -26,24 +26,28 @@ describe("Set", () => {
 		it("compares the elements strictly", () => {
 			fc.assert(
 				fc.property(
-					fc.uniqueArray(fc.anything()).map((xs) => new Set(xs)),
-					fc.uniqueArray(fc.anything()).map((xs) => new Set(xs)),
-					(xs, ys) => {
-						const result = eq(xs, ys);
+					fc
+						.uniqueArray(fc.anything())
+						.map((elems) => new Set(elems)),
+					fc
+						.uniqueArray(fc.anything())
+						.map((elems) => new Set(elems)),
+					(lhs, rhs) => {
+						const result = eq(lhs, rhs);
 
-						const exp = (() => {
-							if (xs.size !== ys.size) {
+						const expected = (() => {
+							if (lhs.size !== rhs.size) {
 								return false;
 							}
-							for (const x of xs) {
-								if (!ys.has(x)) {
+							for (const val of lhs) {
+								if (!rhs.has(val)) {
 									return false;
 								}
 							}
 							return true;
 						})();
 
-						expect(result).to.equal(exp);
+						expect(result).to.equal(expected);
 					},
 				),
 			);
@@ -51,7 +55,7 @@ describe("Set", () => {
 
 		it("implements a lawful equivalence relation", () => {
 			expectLawfulEq(
-				fc.uniqueArray(fc.anything()).map((xs) => new Set(xs)),
+				fc.uniqueArray(fc.anything()).map((elems) => new Set(elems)),
 			);
 		});
 	});
@@ -60,15 +64,19 @@ describe("Set", () => {
 		it("takes the union of the sets", () => {
 			fc.assert(
 				fc.property(
-					fc.uniqueArray(fc.anything()).map((xs) => new Set(xs)),
-					fc.uniqueArray(fc.anything()).map((xs) => new Set(xs)),
-					(xs, ys) => {
-						const result = cmb(xs, ys);
-						const exp = new Set([...xs, ...ys]);
+					fc
+						.uniqueArray(fc.anything())
+						.map((elems) => new Set(elems)),
+					fc
+						.uniqueArray(fc.anything())
+						.map((elems) => new Set(elems)),
+					(lhs, rhs) => {
+						const result = cmb(lhs, rhs);
+						const expected = new Set([...lhs, ...rhs]);
 
-						expect(result.size).to.equal(exp.size);
-						for (const x of result) {
-							expect(exp.has(x)).to.be.true;
+						expect(result.size).to.equal(expected.size);
+						for (const val of result) {
+							expect(expected.has(val)).to.be.true;
 						}
 					},
 				),
@@ -77,7 +85,7 @@ describe("Set", () => {
 
 		it("implements a lawful semigroup", () => {
 			expectLawfulSemigroup(
-				fc.uniqueArray(fc.string()).map((xs) => new Set(xs)),
+				fc.uniqueArray(fc.string()).map((elems) => new Set(elems)),
 			);
 		});
 	});
@@ -86,21 +94,21 @@ describe("Set", () => {
 describe("ReadonlySet", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the readonly set and non-readonly set to each other", () => {
-			const xs: ReadonlySet<unknown> = new Set();
-			const ys: Set<unknown> = new Set();
-			eq(xs, xs);
-			eq(xs, ys);
-			eq(ys, xs);
+			const readonly: ReadonlySet<unknown> = new Set();
+			const writable: Set<unknown> = new Set();
+			eq(readonly, readonly);
+			eq(readonly, writable);
+			eq(writable, readonly);
 		});
 	});
 
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the readonly set and non-readonly set with each other", () => {
-			const xs: ReadonlySet<unknown> = new Set();
-			const ys: Set<unknown> = new Set();
-			cmb(xs, xs);
-			cmb(xs, ys);
-			cmb(ys, xs);
+			const readonly: ReadonlySet<unknown> = new Set();
+			const writable: Set<unknown> = new Set();
+			cmb(readonly, readonly);
+			cmb(readonly, writable);
+			cmb(writable, readonly);
 		});
 	});
 });

--- a/src/string.test.ts
+++ b/src/string.test.ts
@@ -28,11 +28,14 @@ import "./string.js";
 describe("String", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the strings strictly", () => {
-			fc.assert(
-				fc.property(fc.string(), fc.string(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.string(),
+				fc.string(),
+				(lhs, rhs) => {
 					expect(eq(lhs, rhs)).to.equal(lhs === rhs);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -42,8 +45,10 @@ describe("String", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the strings lexicographically by their character code points", () => {
-			fc.assert(
-				fc.property(fc.string(), fc.string(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.string(),
+				fc.string(),
+				(lhs, rhs) => {
 					expect(cmp(lhs, rhs)).to.equal(
 						lhs < rhs
 							? Ordering.less
@@ -51,8 +56,9 @@ describe("String", () => {
 							? Ordering.greater
 							: Ordering.equal,
 					);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -62,11 +68,14 @@ describe("String", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the strings", () => {
-			fc.assert(
-				fc.property(fc.string(), fc.string(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.string(),
+				fc.string(),
+				(lhs, rhs) => {
 					expect(cmb(lhs, rhs)).to.equal(lhs + rhs);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/string.test.ts
+++ b/src/string.test.ts
@@ -29,8 +29,8 @@ describe("String", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the strings strictly", () => {
 			fc.assert(
-				fc.property(fc.string(), fc.string(), (x, y) => {
-					expect(eq(x, y)).to.equal(x === y);
+				fc.property(fc.string(), fc.string(), (lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(lhs === rhs);
 				}),
 			);
 		});
@@ -43,11 +43,11 @@ describe("String", () => {
 	describe("#[Ord.cmp]", () => {
 		it("compares the strings lexicographically by their character code points", () => {
 			fc.assert(
-				fc.property(fc.string(), fc.string(), (x, y) => {
-					expect(cmp(x, y)).to.equal(
-						x < y
+				fc.property(fc.string(), fc.string(), (lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						lhs < rhs
 							? Ordering.less
-							: x > y
+							: lhs > rhs
 							? Ordering.greater
 							: Ordering.equal,
 					);
@@ -63,8 +63,8 @@ describe("String", () => {
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the strings", () => {
 			fc.assert(
-				fc.property(fc.string(), fc.string(), (x, y) => {
-					expect(cmb(x, y)).to.equal(x + y);
+				fc.property(fc.string(), fc.string(), (lhs, rhs) => {
+					expect(cmb(lhs, rhs)).to.equal(lhs + rhs);
 				}),
 			);
 		});

--- a/src/uint16_array.test.ts
+++ b/src/uint16_array.test.ts
@@ -29,9 +29,13 @@ describe("Uint16Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
 			fc.assert(
-				fc.property(fc.uint16Array(), fc.uint16Array(), (xs, ys) => {
-					expect(eq(xs, ys)).to.equal(
-						ieqBy(xs, ys, (x, y) => x === y),
+				fc.property(fc.uint16Array(), fc.uint16Array(), (lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(
+						ieqBy(
+							lhs,
+							rhs,
+							(lhsElem, rhsElem) => lhsElem === rhsElem,
+						),
 					);
 				}),
 			);
@@ -45,9 +49,11 @@ describe("Uint16Array", () => {
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
 			fc.assert(
-				fc.property(fc.uint16Array(), fc.uint16Array(), (xs, ys) => {
-					expect(cmp(xs, ys)).to.equal(
-						icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+				fc.property(fc.uint16Array(), fc.uint16Array(), (lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+							Ordering.fromNumber(lhsElem - rhsElem),
+						),
 					);
 				}),
 			);
@@ -61,15 +67,14 @@ describe("Uint16Array", () => {
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
 			fc.assert(
-				fc.property(fc.uint16Array(), fc.uint16Array(), (xs, ys) => {
-					const result = cmb(xs, ys);
+				fc.property(fc.uint16Array(), fc.uint16Array(), (lhs, rhs) => {
+					const result = cmb(lhs, rhs);
 
-					const exp = new Uint16Array(xs.length + ys.length);
-					exp.set(xs);
-					exp.set(ys, xs.length);
+					const expected = new Uint16Array(lhs.length + rhs.length);
+					expected.set(lhs);
+					expected.set(rhs, lhs.length);
 
-					expect(result).to.deep.equal(exp);
-					expect(exp.length).to.equal(xs.length + ys.length);
+					expect(result).to.deep.equal(expected);
 				}),
 			);
 		});

--- a/src/uint16_array.test.ts
+++ b/src/uint16_array.test.ts
@@ -28,8 +28,10 @@ import "./uint16_array.js";
 describe("Uint16Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(fc.uint16Array(), fc.uint16Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.uint16Array(),
+				fc.uint16Array(),
+				(lhs, rhs) => {
 					expect(eq(lhs, rhs)).to.equal(
 						ieqBy(
 							lhs,
@@ -37,8 +39,9 @@ describe("Uint16Array", () => {
 							(lhsElem, rhsElem) => lhsElem === rhsElem,
 						),
 					);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -48,15 +51,18 @@ describe("Uint16Array", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(fc.uint16Array(), fc.uint16Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.uint16Array(),
+				fc.uint16Array(),
+				(lhs, rhs) => {
 					expect(cmp(lhs, rhs)).to.equal(
 						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
 							Ordering.fromNumber(lhsElem - rhsElem),
 						),
 					);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -66,8 +72,10 @@ describe("Uint16Array", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
-			fc.assert(
-				fc.property(fc.uint16Array(), fc.uint16Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.uint16Array(),
+				fc.uint16Array(),
+				(lhs, rhs) => {
 					const result = cmb(lhs, rhs);
 
 					const expected = new Uint16Array(lhs.length + rhs.length);
@@ -75,8 +83,9 @@ describe("Uint16Array", () => {
 					expected.set(rhs, lhs.length);
 
 					expect(result).to.deep.equal(expected);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/uint32_array.test.ts
+++ b/src/uint32_array.test.ts
@@ -29,9 +29,13 @@ describe("Uint32Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
 			fc.assert(
-				fc.property(fc.uint32Array(), fc.uint32Array(), (xs, ys) => {
-					expect(eq(xs, ys)).to.equal(
-						ieqBy(xs, ys, (x, y) => x === y),
+				fc.property(fc.uint32Array(), fc.uint32Array(), (lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(
+						ieqBy(
+							lhs,
+							rhs,
+							(lhsElem, rhsElem) => lhsElem === rhsElem,
+						),
 					);
 				}),
 			);
@@ -45,9 +49,11 @@ describe("Uint32Array", () => {
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
 			fc.assert(
-				fc.property(fc.uint32Array(), fc.uint32Array(), (xs, ys) => {
-					expect(cmp(xs, ys)).to.equal(
-						icmpBy(xs, ys, (x, y) => Ordering.fromNumber(x - y)),
+				fc.property(fc.uint32Array(), fc.uint32Array(), (lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+							Ordering.fromNumber(lhsElem - rhsElem),
+						),
 					);
 				}),
 			);
@@ -61,15 +67,14 @@ describe("Uint32Array", () => {
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
 			fc.assert(
-				fc.property(fc.uint32Array(), fc.uint32Array(), (xs, ys) => {
-					const result = cmb(xs, ys);
+				fc.property(fc.uint32Array(), fc.uint32Array(), (lhs, rhs) => {
+					const result = cmb(lhs, rhs);
 
-					const exp = new Uint32Array(xs.length + ys.length);
-					exp.set(xs);
-					exp.set(ys, xs.length);
+					const expected = new Uint32Array(lhs.length + rhs.length);
+					expected.set(lhs);
+					expected.set(rhs, lhs.length);
 
-					expect(result).to.deep.equal(exp);
-					expect(exp.length).to.equal(xs.length + ys.length);
+					expect(result).to.deep.equal(expected);
 				}),
 			);
 		});

--- a/src/uint32_array.test.ts
+++ b/src/uint32_array.test.ts
@@ -28,8 +28,10 @@ import "./uint32_array.js";
 describe("Uint32Array", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(fc.uint32Array(), fc.uint32Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.uint32Array(),
+				fc.uint32Array(),
+				(lhs, rhs) => {
 					expect(eq(lhs, rhs)).to.equal(
 						ieqBy(
 							lhs,
@@ -37,8 +39,9 @@ describe("Uint32Array", () => {
 							(lhsElem, rhsElem) => lhsElem === rhsElem,
 						),
 					);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -48,15 +51,18 @@ describe("Uint32Array", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(fc.uint32Array(), fc.uint32Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.uint32Array(),
+				fc.uint32Array(),
+				(lhs, rhs) => {
 					expect(cmp(lhs, rhs)).to.equal(
 						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
 							Ordering.fromNumber(lhsElem - rhsElem),
 						),
 					);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -66,8 +72,10 @@ describe("Uint32Array", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
-			fc.assert(
-				fc.property(fc.uint32Array(), fc.uint32Array(), (lhs, rhs) => {
+			const property = fc.property(
+				fc.uint32Array(),
+				fc.uint32Array(),
+				(lhs, rhs) => {
 					const result = cmb(lhs, rhs);
 
 					const expected = new Uint32Array(lhs.length + rhs.length);
@@ -75,8 +83,9 @@ describe("Uint32Array", () => {
 					expected.set(rhs, lhs.length);
 
 					expect(result).to.deep.equal(expected);
-				}),
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/uint8_array.test.ts
+++ b/src/uint8_array.test.ts
@@ -30,11 +30,19 @@ describe("uint8_array.js", () => {
 		describe("#[Eq.eq]", () => {
 			it("compares the arrays lexicographically", () => {
 				fc.assert(
-					fc.property(fc.uint8Array(), fc.uint8Array(), (xs, ys) => {
-						expect(eq(xs, ys)).to.equal(
-							ieqBy(xs, ys, (x, y) => x === y),
-						);
-					}),
+					fc.property(
+						fc.uint8Array(),
+						fc.uint8Array(),
+						(lhs, rhs) => {
+							expect(eq(lhs, rhs)).to.equal(
+								ieqBy(
+									lhs,
+									rhs,
+									(lhsElem, rhsElem) => lhsElem === rhsElem,
+								),
+							);
+						},
+					),
 				);
 			});
 
@@ -46,13 +54,17 @@ describe("uint8_array.js", () => {
 		describe("#[Ord.cmp]", () => {
 			it("compares the arrays lexicographically", () => {
 				fc.assert(
-					fc.property(fc.uint8Array(), fc.uint8Array(), (xs, ys) => {
-						expect(cmp(xs, ys)).to.equal(
-							icmpBy(xs, ys, (x, y) =>
-								Ordering.fromNumber(x - y),
-							),
-						);
-					}),
+					fc.property(
+						fc.uint8Array(),
+						fc.uint8Array(),
+						(lhs, rhs) => {
+							expect(cmp(lhs, rhs)).to.equal(
+								icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+									Ordering.fromNumber(lhsElem - rhsElem),
+								),
+							);
+						},
+					),
 				);
 			});
 
@@ -64,16 +76,21 @@ describe("uint8_array.js", () => {
 		describe("#[Semigroup.cmb]", () => {
 			it("concatenates the arrays", () => {
 				fc.assert(
-					fc.property(fc.uint8Array(), fc.uint8Array(), (xs, ys) => {
-						const result = cmb(xs, ys);
+					fc.property(
+						fc.uint8Array(),
+						fc.uint8Array(),
+						(lhs, rhs) => {
+							const result = cmb(lhs, rhs);
 
-						const exp = new Uint8Array(xs.length + ys.length);
-						exp.set(xs);
-						exp.set(ys, xs.length);
+							const expected = new Uint8Array(
+								lhs.length + rhs.length,
+							);
+							expected.set(lhs);
+							expected.set(rhs, lhs.length);
 
-						expect(result).to.deep.equal(exp);
-						expect(exp.length).to.equal(xs.length + ys.length);
-					}),
+							expect(result).to.deep.equal(expected);
+						},
+					),
 				);
 			});
 

--- a/src/uint8_array.test.ts
+++ b/src/uint8_array.test.ts
@@ -29,21 +29,20 @@ describe("uint8_array.js", () => {
 	describe("Uint8Array", () => {
 		describe("#[Eq.eq]", () => {
 			it("compares the arrays lexicographically", () => {
-				fc.assert(
-					fc.property(
-						fc.uint8Array(),
-						fc.uint8Array(),
-						(lhs, rhs) => {
-							expect(eq(lhs, rhs)).to.equal(
-								ieqBy(
-									lhs,
-									rhs,
-									(lhsElem, rhsElem) => lhsElem === rhsElem,
-								),
-							);
-						},
-					),
+				const property = fc.property(
+					fc.uint8Array(),
+					fc.uint8Array(),
+					(lhs, rhs) => {
+						expect(eq(lhs, rhs)).to.equal(
+							ieqBy(
+								lhs,
+								rhs,
+								(lhsElem, rhsElem) => lhsElem === rhsElem,
+							),
+						);
+					},
 				);
+				fc.assert(property);
 			});
 
 			it("implements a lawful equivalence relation", () => {
@@ -53,19 +52,18 @@ describe("uint8_array.js", () => {
 
 		describe("#[Ord.cmp]", () => {
 			it("compares the arrays lexicographically", () => {
-				fc.assert(
-					fc.property(
-						fc.uint8Array(),
-						fc.uint8Array(),
-						(lhs, rhs) => {
-							expect(cmp(lhs, rhs)).to.equal(
-								icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
-									Ordering.fromNumber(lhsElem - rhsElem),
-								),
-							);
-						},
-					),
+				const property = fc.property(
+					fc.uint8Array(),
+					fc.uint8Array(),
+					(lhs, rhs) => {
+						expect(cmp(lhs, rhs)).to.equal(
+							icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+								Ordering.fromNumber(lhsElem - rhsElem),
+							),
+						);
+					},
 				);
+				fc.assert(property);
 			});
 
 			it("implements a lawful total order", () => {
@@ -75,23 +73,22 @@ describe("uint8_array.js", () => {
 
 		describe("#[Semigroup.cmb]", () => {
 			it("concatenates the arrays", () => {
-				fc.assert(
-					fc.property(
-						fc.uint8Array(),
-						fc.uint8Array(),
-						(lhs, rhs) => {
-							const result = cmb(lhs, rhs);
+				const property = fc.property(
+					fc.uint8Array(),
+					fc.uint8Array(),
+					(lhs, rhs) => {
+						const result = cmb(lhs, rhs);
 
-							const expected = new Uint8Array(
-								lhs.length + rhs.length,
-							);
-							expected.set(lhs);
-							expected.set(rhs, lhs.length);
+						const expected = new Uint8Array(
+							lhs.length + rhs.length,
+						);
+						expected.set(lhs);
+						expected.set(rhs, lhs.length);
 
-							expect(result).to.deep.equal(expected);
-						},
-					),
+						expect(result).to.deep.equal(expected);
+					},
 				);
+				fc.assert(property);
 			});
 
 			it("implements a lawful semigroup", () => {

--- a/src/uint8_array.test.ts
+++ b/src/uint8_array.test.ts
@@ -25,75 +25,71 @@ import {
 } from "./_test/utils.js";
 import "./uint8_array.js";
 
-describe("uint8_array.js", () => {
-	describe("Uint8Array", () => {
-		describe("#[Eq.eq]", () => {
-			it("compares the arrays lexicographically", () => {
-				const property = fc.property(
-					fc.uint8Array(),
-					fc.uint8Array(),
-					(lhs, rhs) => {
-						expect(eq(lhs, rhs)).to.equal(
-							ieqBy(
-								lhs,
-								rhs,
-								(lhsElem, rhsElem) => lhsElem === rhsElem,
-							),
-						);
-					},
-				);
-				fc.assert(property);
-			});
-
-			it("implements a lawful equivalence relation", () => {
-				expectLawfulEq(fc.uint8Array());
-			});
+describe("Uint8Array", () => {
+	describe("#[Eq.eq]", () => {
+		it("compares the arrays lexicographically", () => {
+			const property = fc.property(
+				fc.uint8Array(),
+				fc.uint8Array(),
+				(lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(
+						ieqBy(
+							lhs,
+							rhs,
+							(lhsElem, rhsElem) => lhsElem === rhsElem,
+						),
+					);
+				},
+			);
+			fc.assert(property);
 		});
 
-		describe("#[Ord.cmp]", () => {
-			it("compares the arrays lexicographically", () => {
-				const property = fc.property(
-					fc.uint8Array(),
-					fc.uint8Array(),
-					(lhs, rhs) => {
-						expect(cmp(lhs, rhs)).to.equal(
-							icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
-								Ordering.fromNumber(lhsElem - rhsElem),
-							),
-						);
-					},
-				);
-				fc.assert(property);
-			});
+		it("implements a lawful equivalence relation", () => {
+			expectLawfulEq(fc.uint8Array());
+		});
+	});
 
-			it("implements a lawful total order", () => {
-				expectLawfulOrd(fc.uint8Array());
-			});
+	describe("#[Ord.cmp]", () => {
+		it("compares the arrays lexicographically", () => {
+			const property = fc.property(
+				fc.uint8Array(),
+				fc.uint8Array(),
+				(lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+							Ordering.fromNumber(lhsElem - rhsElem),
+						),
+					);
+				},
+			);
+			fc.assert(property);
 		});
 
-		describe("#[Semigroup.cmb]", () => {
-			it("concatenates the arrays", () => {
-				const property = fc.property(
-					fc.uint8Array(),
-					fc.uint8Array(),
-					(lhs, rhs) => {
-						const result = cmb(lhs, rhs);
+		it("implements a lawful total order", () => {
+			expectLawfulOrd(fc.uint8Array());
+		});
+	});
 
-						const expected = new Uint8Array(
-							lhs.length + rhs.length,
-						);
-						expected.set(lhs);
-						expected.set(rhs, lhs.length);
+	describe("#[Semigroup.cmb]", () => {
+		it("concatenates the arrays", () => {
+			const property = fc.property(
+				fc.uint8Array(),
+				fc.uint8Array(),
+				(lhs, rhs) => {
+					const result = cmb(lhs, rhs);
 
-						expect(result).to.deep.equal(expected);
-					},
-				);
-				fc.assert(property);
-			});
+					const expected = new Uint8Array(lhs.length + rhs.length);
+					expected.set(lhs);
+					expected.set(rhs, lhs.length);
 
-			it("implements a lawful semigroup", () => {
-				expectLawfulSemigroup(fc.uint8Array());
-			});
+					expect(result).to.deep.equal(expected);
+				},
+			);
+			fc.assert(property);
+		});
+
+		it("implements a lawful semigroup", () => {
+			expectLawfulSemigroup(fc.uint8Array());
 		});
 	});
 });

--- a/src/uint8_clamped_array.test.ts
+++ b/src/uint8_clamped_array.test.ts
@@ -28,21 +28,20 @@ import "./uint8_clamped_array.js";
 describe("Uint8ClampedArray", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(
-					fc.uint8ClampedArray(),
-					fc.uint8ClampedArray(),
-					(lhs, rhs) => {
-						expect(eq(lhs, rhs)).to.equal(
-							ieqBy(
-								lhs,
-								rhs,
-								(lhsElem, rhsElem) => lhsElem === rhsElem,
-							),
-						);
-					},
-				),
+			const property = fc.property(
+				fc.uint8ClampedArray(),
+				fc.uint8ClampedArray(),
+				(lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(
+						ieqBy(
+							lhs,
+							rhs,
+							(lhsElem, rhsElem) => lhsElem === rhsElem,
+						),
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -52,19 +51,18 @@ describe("Uint8ClampedArray", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the arrays lexicographically", () => {
-			fc.assert(
-				fc.property(
-					fc.uint8ClampedArray(),
-					fc.uint8ClampedArray(),
-					(lhs, rhs) => {
-						expect(cmp(lhs, rhs)).to.equal(
-							icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
-								Ordering.fromNumber(lhsElem - rhsElem),
-							),
-						);
-					},
-				),
+			const property = fc.property(
+				fc.uint8ClampedArray(),
+				fc.uint8ClampedArray(),
+				(lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+							Ordering.fromNumber(lhsElem - rhsElem),
+						),
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -74,23 +72,22 @@ describe("Uint8ClampedArray", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the arrays", () => {
-			fc.assert(
-				fc.property(
-					fc.uint8ClampedArray(),
-					fc.uint8ClampedArray(),
-					(lhs, rhs) => {
-						const result = cmb(lhs, rhs);
+			const property = fc.property(
+				fc.uint8ClampedArray(),
+				fc.uint8ClampedArray(),
+				(lhs, rhs) => {
+					const result = cmb(lhs, rhs);
 
-						const expected = new Uint8ClampedArray(
-							lhs.length + rhs.length,
-						);
-						expected.set(lhs);
-						expected.set(rhs, lhs.length);
+					const expected = new Uint8ClampedArray(
+						lhs.length + rhs.length,
+					);
+					expected.set(lhs);
+					expected.set(rhs, lhs.length);
 
-						expect(result).to.deep.equal(expected);
-					},
-				),
+					expect(result).to.deep.equal(expected);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/uint8_clamped_array.test.ts
+++ b/src/uint8_clamped_array.test.ts
@@ -32,9 +32,13 @@ describe("Uint8ClampedArray", () => {
 				fc.property(
 					fc.uint8ClampedArray(),
 					fc.uint8ClampedArray(),
-					(xs, ys) => {
-						expect(eq(xs, ys)).to.equal(
-							ieqBy(xs, ys, (x, y) => x === y),
+					(lhs, rhs) => {
+						expect(eq(lhs, rhs)).to.equal(
+							ieqBy(
+								lhs,
+								rhs,
+								(lhsElem, rhsElem) => lhsElem === rhsElem,
+							),
 						);
 					},
 				),
@@ -52,10 +56,10 @@ describe("Uint8ClampedArray", () => {
 				fc.property(
 					fc.uint8ClampedArray(),
 					fc.uint8ClampedArray(),
-					(xs, ys) => {
-						expect(cmp(xs, ys)).to.equal(
-							icmpBy(xs, ys, (x, y) =>
-								Ordering.fromNumber(x - y),
+					(lhs, rhs) => {
+						expect(cmp(lhs, rhs)).to.equal(
+							icmpBy(lhs, rhs, (lhsElem, rhsElem) =>
+								Ordering.fromNumber(lhsElem - rhsElem),
 							),
 						);
 					},
@@ -74,17 +78,16 @@ describe("Uint8ClampedArray", () => {
 				fc.property(
 					fc.uint8ClampedArray(),
 					fc.uint8ClampedArray(),
-					(xs, ys) => {
-						const result = cmb(xs, ys);
+					(lhs, rhs) => {
+						const result = cmb(lhs, rhs);
 
-						const exp = new Uint8ClampedArray(
-							xs.length + ys.length,
+						const expected = new Uint8ClampedArray(
+							lhs.length + rhs.length,
 						);
-						exp.set(xs);
-						exp.set(ys, xs.length);
+						expected.set(lhs);
+						expected.set(rhs, lhs.length);
 
-						expect(result).to.deep.equal(exp);
-						expect(exp.length).to.equal(xs.length + ys.length);
+						expect(result).to.deep.equal(expected);
 					},
 				),
 			);


### PR DESCRIPTION
- Choose better names for variables in the unit tests.
- Un-nest fast-check properties from fast-check assertions to minimize indentation.
- Remove stale module-level test suite blocks, Vitest already splits the suites by files.
- Add a missing test suite block for `Float32Array`.